### PR TITLE
Add idtoken response

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -73,6 +73,14 @@ vouch:
     jwt: X-Vouch-Token
     querystring: access_token
     redirect: X-Vouch-Requested-URI
+    # If idToken is defined, all valid requests to /validate will receive a header (defined in the value) containing the id_token from the OpenID Provider
+    # If idToken is empty or undefined, no header will be added
+    # This will make the response largerwich in turn can affect the response time
+    # idToken: x-vouch-idtoken
+    # If accessToken is defined, all valid requests to /validate will receive a header (defined in the value) containing the access_token from the OpenID Provider
+    # If accessToken is empty or undefined, no header will be added
+    # This will make the response larger wich in turn can affect the response time
+    # accessToken: x-vouch-accesstoken
 
   db: 
     file: data/vouch_bolt.db

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -192,11 +192,11 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Add(cfg.Cfg.Headers.User, claims.Username)
-	if cfg.Get("Headers.IDToken") != "" {
-		w.Header().Add(cfg.Get("Headers.IDToken"), claims.IDToken)
+	if cfg.Cfg.Headers.IDToken != "" {
+		w.Header().Add(cfg.Cfg.Headers.IDToken, claims.IDToken)
 	}
-	if cfg.Get("Headers.AccessToken") != "" {
-		w.Header().Add(cfg.Get("Headers.AccessToken"), claims.AccessToken)
+	if cfg.Cfg.Headers.AccessToken != "" {
+		w.Header().Add(cfg.Cfg.Headers.AccessToken, claims.AccessToken)
 	}
 	w.Header().Add(cfg.Cfg.Headers.Success, "true")
 	log.WithFields(log.Fields{cfg.Cfg.Headers.User: w.Header().Get(cfg.Cfg.Headers.User)}).Debug("response header")

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -190,6 +190,12 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Add(cfg.Cfg.Headers.User, claims.Username)
+	if cfg.Get("Headers.IDToken") != "" {
+		w.Header().Add(cfg.Get("Headers.IDToken"), claims.IDToken)
+	}
+	if cfg.Get("Headers.AccessToken") != "" {
+		w.Header().Add(cfg.Get("Headers.AccessToken"), claims.AccessToken)
+	}
 	w.Header().Add(cfg.Cfg.Headers.Success, "true")
 	log.WithFields(log.Fields{cfg.Cfg.Headers.User: w.Header().Get(cfg.Cfg.Headers.User)}).Debug("response header")
 
@@ -638,6 +644,8 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User) error {
 
 	adfsUser.PrepareUserData()
 	user.Username = adfsUser.UPN
+	user.IDToken = string(tokenRes.IDToken)
+	user.AccessToken = string(tokenRes.AccessToken)
 	log.Debug(user)
 	return nil
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -48,7 +48,7 @@ var (
 func randString() string {
 	b := make([]byte, 32)
 	rand.Read(b)
-	return base64.StdEncoding.EncodeToString(b)
+	return base64.URLEncoding.EncodeToString(b)
 }
 
 func loginURL(r *http.Request, state string) string {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -10,6 +10,8 @@ import (
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
+	"net/url"
+	"strconv"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -424,6 +426,8 @@ func getUserInfo(r *http.Request, user *structs.User) error {
 	// indieauth sends the "me" setting in json back to the callback, so just pluck it from the callback
 	if cfg.GenOAuth.Provider == cfg.Providers.IndieAuth {
 		return getUserInfoFromIndieAuth(r, user)
+	} else if cfg.GenOAuth.Provider == cfg.Providers.ADFS {
+		return getUserInfoFromADFS(r, user)
 	}
 
 	providerToken, err := cfg.OAuthClient.Exchange(oauth2.NoContext, r.URL.Query().Get("code"))
@@ -565,6 +569,75 @@ func getUserInfoFromIndieAuth(r *http.Request, user *structs.User) error {
 	}
 	iaUser.PrepareUserData()
 	user.Username = iaUser.Username
+	log.Debug(user)
+	return nil
+}
+
+// More info: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers#supported-scenarios
+func getUserInfoFromADFS(r *http.Request, user *structs.User) error {
+	code := r.URL.Query().Get("code")
+	log.Errorf("code: %s", code)
+
+	formData := url.Values{}
+	formData.Set("code", code)
+	formData.Set("grant_type", "authorization_code")
+	formData.Set("resource", cfg.GenOAuth.RedirectURL)
+	formData.Set("client_id", cfg.GenOAuth.ClientID)
+	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
+	formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
+
+	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Content-Length", strconv.Itoa(len(formData.Encode())))
+	req.Header.Set("Accept", "application/json")
+
+	// v := url.Values{}
+	// userinfo, err := client.PostForm(cfg.GenOAuth.UserInfoURL, v)
+
+	client := &http.Client{}
+	userinfo, err := client.Do(req)
+
+	if err != nil {
+		// http.Error(w, err.Error(), http.StatusBadRequest)
+		return err
+	}
+	defer userinfo.Body.Close()
+
+	body, _ := ioutil.ReadAll(userinfo.Body)
+
+	var tokenRes struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		IDToken     string `json:"id_token"`
+		ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
+	}
+
+	if err := json.Unmarshal(body, &tokenRes); err != nil {
+		log.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil
+	}
+
+	s := strings.Split(tokenRes.IDToken, ".")
+	if len(s) < 2 {
+		log.Error("jws: invalid token received")
+		return nil
+	}
+
+	idToken, err := base64.RawURLEncoding.DecodeString(s[1])
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+
+	adfsUser := structs.ADFSUser{}
+	json.Unmarshal([]byte(idToken), &adfsUser)
+	log.Println("adfs adfsUser: ", adfsUser)
+
+	adfsUser.PrepareUserData()
+	user.Username = adfsUser.UPN
 	log.Debug(user)
 	return nil
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -217,16 +217,6 @@ func Get(key string) string {
 	return viper.GetString(key)
 }
 
-// GetInt int value for key
-func GetInt(key string) int {
-	return viper.GetInt(key)
-}
-
-// GetBool bool value for key
-func GetBool(key string) bool {
-	return viper.GetBool(key)
-}
-
 // BasicTest just a quick sanity check to see if the config is sound
 func BasicTest() error {
 	for _, opt := range RequiredOptions {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -213,6 +213,16 @@ func Get(key string) string {
 	return viper.GetString(key)
 }
 
+// Get int value for key
+func GetInt(key string) int {
+	return viper.GetInt(key)
+}
+
+// Get bool value for key
+func GetBool(key string) bool {
+	return viper.GetBool(key)
+}
+
 // BasicTest just a quick sanity check to see if the config is sound
 func BasicTest() error {
 	for _, opt := range RequiredOptions {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -79,6 +79,7 @@ type OAuthProviders struct {
 	Google    string
 	GitHub    string
 	IndieAuth string
+	ADFS      string
 	OIDC      string
 }
 
@@ -113,6 +114,7 @@ var (
 		Google:    "google",
 		GitHub:    "github",
 		IndieAuth: "indieauth",
+		ADFS:      "adfs",
 		OIDC:      "oidc",
 	}
 
@@ -213,12 +215,12 @@ func Get(key string) string {
 	return viper.GetString(key)
 }
 
-// Get int value for key
+// GetInt int value for key
 func GetInt(key string) int {
 	return viper.GetInt(key)
 }
 
-// Get bool value for key
+// GetBool bool value for key
 func GetBool(key string) bool {
 	return viper.GetBool(key)
 }
@@ -246,8 +248,8 @@ func BasicTest() error {
 	case GenOAuth.Provider != Providers.Google && GenOAuth.AuthURL == "":
 		// everyone except IndieAuth and Google has an authURL
 		return errors.New("configuration error: oauth.auth_url not found")
-	case GenOAuth.Provider != Providers.Google && GenOAuth.Provider != Providers.IndieAuth && GenOAuth.UserInfoURL == "":
-		// everyone except IndieAuth and Google has an userInfoURL
+	case GenOAuth.Provider != Providers.Google && GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.ADFS && GenOAuth.UserInfoURL == "":
+		// everyone except IndieAuth, Google and ADFS has an userInfoURL
 		return errors.New("configuration error: oauth.user_info_url not found")
 	}
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -42,6 +42,8 @@ type config struct {
 	}
 	Headers struct {
 		JWT         string `mapstructure:"jwt"`
+		IDToken     string `mapstructure:"idToken"`
+		AccessToken string `mapstructure:"accessToken"`
 		User        string `mapstructure:"user"`
 		QueryString string `mapstructure:"querystring"`
 		Redirect    string `mapstructure:"redirect"`
@@ -363,6 +365,12 @@ func setDefaults() {
 	// headers defaults
 	if !viper.IsSet(Branding.LCName + ".headers.jwt") {
 		Cfg.Headers.JWT = "X-" + Branding.CcName + "-Token"
+	}
+	if !viper.IsSet(Branding.LCName + ".headers.idToken") {
+		Cfg.Headers.IDToken = ""
+	}
+	if !viper.IsSet(Branding.LCName + ".headers.accessToken") {
+		Cfg.Headers.AccessToken = ""
 	}
 	if !viper.IsSet(Branding.LCName + ".headers.querystring") {
 		Cfg.Headers.QueryString = "access_token"

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -10,8 +10,7 @@ import (
 	"github.com/vouch/vouch-proxy/pkg/domains"
 )
 
-var defaultMaxAge = cfg.GetInt("JWT.MaxAge") * 60
-
+var defaultMaxAge = cfg.Cfg.JWT.MaxAge * 60
 
 // SetCookie http
 func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
@@ -25,25 +24,25 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 	}
 	domain := domains.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
-	if cfg.Get("Cookie.Domain") != "" {
-		domain = cfg.Get("Cookie.Domain")
+	if cfg.Cfg.Cookie.Domain != "" {
+		domain = cfg.Cfg.Cookie.Domain
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
 	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
 	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Get("Cookie.Name"),
+		Name:     cfg.Cfg.Cookie.Name,
 		Value:    val,
 		Path:     "/",
 		Domain:   domain,
 		MaxAge:   maxAge,
-		Secure:   cfg.GetBool("Cookie.Secure"),
-		HttpOnly: cfg.GetBool("Cookie.HTTPOnly"),
+		Secure:   cfg.Cfg.Cookie.Secure,
+		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
 	})
 }
 
 // Cookie get the vouch jwt cookie
 func Cookie(r *http.Request) (string, error) {
-	cookie, err := r.Cookie(cfg.Get("Cookie.Name"))
+	cookie, err := r.Cookie(cfg.Cfg.Cookie.Name)
 	if err != nil {
 		return "", err
 	}
@@ -52,7 +51,7 @@ func Cookie(r *http.Request) (string, error) {
 	}
 
 	log.WithFields(log.Fields{
-		"cookieName":  cfg.Get("Cookie.Name"),
+		"cookieName":  cfg.Cfg.Cookie.Name,
 		"cookieValue": cookie.Value,
 	}).Debug("cookie")
 	return cookie.Value, err

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -10,7 +10,8 @@ import (
 	"github.com/vouch/vouch-proxy/pkg/domains"
 )
 
-var defaultMaxAge = cfg.Cfg.JWT.MaxAge * 60
+var defaultMaxAge = cfg.GetInt("JWT.MaxAge") * 60
+
 
 // SetCookie http
 func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
@@ -24,25 +25,25 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 	}
 	domain := domains.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
-	if cfg.Cfg.Cookie.Domain != "" {
-		domain = cfg.Cfg.Cookie.Domain
+	if cfg.Get("Cookie.Domain") != "" {
+		domain = cfg.Get("Cookie.Domain")
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
 	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
 	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Cfg.Cookie.Name,
+		Name:     cfg.Get("Cookie.Name"),
 		Value:    val,
 		Path:     "/",
 		Domain:   domain,
 		MaxAge:   maxAge,
-		Secure:   cfg.Cfg.Cookie.Secure,
-		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+		Secure:   cfg.GetBool("Cookie.Secure"),
+		HttpOnly: cfg.GetBool("Cookie.HTTPOnly"),
 	})
 }
 
 // Cookie get the vouch jwt cookie
 func Cookie(r *http.Request) (string, error) {
-	cookie, err := r.Cookie(cfg.Cfg.Cookie.Name)
+	cookie, err := r.Cookie(cfg.Get("Cookie.Name"))
 	if err != nil {
 		return "", err
 	}
@@ -51,7 +52,7 @@ func Cookie(r *http.Request) (string, error) {
 	}
 
 	log.WithFields(log.Fields{
-		"cookieName":  cfg.Cfg.Cookie.Name,
+		"cookieName":  cfg.Get("Cookie.Name"),
 		"cookieValue": cookie.Value,
 	}).Debug("cookie")
 	return cookie.Value, err

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -21,8 +21,10 @@ import (
 
 // VouchClaims jwt Claims specific to vouch
 type VouchClaims struct {
-	Username string   `json:"username"`
-	Sites    []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
+	Username    string   `json:"username"`
+	Sites       []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
+	IDToken     string   `json:"id_token"`
+	AccessToken string   `json:"access_token"`
 	jwt.StandardClaims
 }
 
@@ -53,6 +55,8 @@ func CreateUserTokenString(u structs.User) string {
 	claims := VouchClaims{
 		u.Username,
 		Sites,
+		u.IDToken,
+		u.AccessToken,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -26,6 +26,8 @@ func init() {
 	lc = VouchClaims{
 		u1.Username,
 		Sites,
+		u1.IDToken,
+		u1.AccessToken,
 		StandardClaims,
 	}
 }

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -47,6 +47,22 @@ func (u *GoogleUser) PrepareUserData() {
 	u.Username = u.Email
 }
 
+type ADFSUser struct {
+	User
+	Sub string `json:"sub"`
+	UPN string `json:"upn"`
+	// UniqueName string `json:"unique_name"`
+	// PwdExp     string `json:"pwd_exp"`
+	// SID        string `json:"sid"`
+	// Groups     string `json:"groups"`
+	// jwt.StandardClaims
+}
+
+// PrepareUserData implement PersonalData interface
+func (u *ADFSUser) PrepareUserData() {
+	u.Username = u.UPN
+}
+
 // GitHubUser is a retrieved and authentiacted user from GitHub.
 type GitHubUser struct {
 	User

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -10,12 +10,14 @@ type User struct {
 	// TODO: set Provider here so that we can pass it to db
 	// populated by db (via mapstructure) or from provider (via json)
 	// Provider   string `json:"provider",mapstructure:"provider"`
-	Username   string `json:"username",mapstructure:"username"`
-	Name       string `json:"name",mapstructure:"name"`
-	Email      string `json:"email",mapstructure:"email"`
-	CreatedOn  int64  `json:"createdon"`
-	LastUpdate int64  `json:"lastupdate"`
-	ID         int    `json:"id",mapstructure:"id"`
+	Username    string `json:"username",mapstructure:"username"`
+	Name        string `json:"name",mapstructure:"name"`
+	Email       string `json:"email",mapstructure:"email"`
+	CreatedOn   int64  `json:"createdon"`
+	LastUpdate  int64  `json:"lastupdate"`
+	ID          int    `json:"id",mapstructure:"id"`
+	IDToken     string `json:"id_token",mapstructure:"id_token"`
+	AccessToken string `json:"access_token,mapstructure:"id_token"`
 	// jwt.StandardClaims
 }
 


### PR DESCRIPTION
Makes it possible to configure the following two headers:
* idToken
* accessToken

If they are empty in the configuration, nothing will be added. If configured, they will be added as response headers.

Example:
```
vouch:
  headers:
    idToken: x-vouch-idtoken
```

This will make it possible to use it in nginx like this:
```
auth_request_set $auth_resp_x_vouch_idtoken $upstream_http_x_vouch_idtoken;
```

And then use the upstream header to, for example, add it to the backend:
```
proxy_set_header Authorization "Bearer $auth_resp_x_vouch_idtoken";
```