### PR TITLE
Add user.IDToken and user.AccessToken to ADFSUser

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -645,6 +645,8 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User) error {
 
 	adfsUser.PrepareUserData()
 	user.Username = adfsUser.Username
+	user.IDToken = string(tokenRes.IDToken)
+	user.AccessToken = string(tokenRes.AccessToken)
 	log.Debug(user)
 	return nil
 }


### PR DESCRIPTION
This will only add it to users with ADFS, not for providers as of now.