### PR TITLE
Change logrus imports to lowercase

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gorilla/sessions"
 	"github.com/vouch/vouch-proxy/pkg/cfg"

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/github"
 	"golang.org/x/oauth2/google"

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -3,8 +3,8 @@ package cfg
 import (
 	"testing"
 	// "github.com/vouch/vouch-proxy/pkg/structs"
-	// log "github.com/Sirupsen/logrus"
-	log "github.com/Sirupsen/logrus"
+	// log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	// "github.com/vouch/vouch-proxy/pkg/structs"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/domains"
 )

--- a/pkg/cors/cors.go
+++ b/pkg/cors/cors.go
@@ -3,7 +3,7 @@ package cors
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // AllowAll is middle ware to set Access-Control-Allow-Origin: *

--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 )
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 
-	// log "github.com/Sirupsen/logrus"
-	log "github.com/Sirupsen/logrus"
+	// log "github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 )
 

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 

--- a/pkg/model/site.go
+++ b/pkg/model/site.go
@@ -5,8 +5,8 @@ import (
 	"encoding/gob"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 )
 

--- a/pkg/model/team.go
+++ b/pkg/model/team.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 )
 

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/boltdb/bolt"
+	log "github.com/sirupsen/logrus"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 )
 

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -1,7 +1,7 @@
 package response
 
 import "net/http"
-import log "github.com/Sirupsen/logrus"
+import log "github.com/sirupsen/logrus"
 
 // we wrap ResponseWriter so that we can store the StatusCode
 // and then pull it out later for logging

--- a/pkg/timelog/timelog.go
+++ b/pkg/timelog/timelog.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/vouch/vouch-proxy/pkg/response"
 
-	log "github.com/Sirupsen/logrus"
 	isatty "github.com/mattn/go-isatty"
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/transciever/client.go
+++ b/pkg/transciever/client.go
@@ -9,8 +9,8 @@ import (
 	"github.com/vouch/vouch-proxy/pkg/model"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/mitchellh/mapstructure"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/gorilla/websocket"
 )

--- a/pkg/transciever/transciever.go
+++ b/pkg/transciever/transciever.go
@@ -3,7 +3,7 @@ package transciever
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // WSHandler implements the Handler Interface


### PR DESCRIPTION
Please see issue 933 on logrus project (https://github.com/sirupsen/logrus/issues/933).
According to their readme:
`Seeing weird case-sensitive problems? It's in the past been possible to import Logrus as both upper- and lower-case. Due to the Go package environment, this caused issues in the community and we needed a standard. Some environments experienced problems with the upper-case variant, so the lower-case was decided. Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.`

The uppercase was causing errors building and running vouch due to their use of internal packages.  The fix is to use the proper lowercase import as they described in their readme.