### PR TITLE
Make client_secret optional for oidc and adfs

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -591,8 +591,9 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User) error {
 	formData.Set("resource", cfg.GenOAuth.RedirectURL)
 	formData.Set("client_id", cfg.GenOAuth.ClientID)
 	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
-	formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
-
+	if cfg.GenOAuth.ClientSecret != "" {
+		formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
+	}
 	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
 	if err != nil {
 		return err

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -232,8 +232,9 @@ func BasicTest() error {
 	case GenOAuth.ClientID == "":
 		// everyone has a clientID
 		return errors.New("configuration error: oauth.client_id not found")
-	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.ClientSecret == "":
+	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.ADFS && GenOAuth.Provider != Providers.OIDC && GenOAuth.ClientSecret == "":
 		// everyone except IndieAuth has a clientSecret
+		// ADFS and OIDC providers also do not require this, but can have it optionally set.
 		return errors.New("configuration error: o`auth.client_secret not found")
 	case GenOAuth.Provider != Providers.Google && GenOAuth.AuthURL == "":
 		// everyone except IndieAuth and Google has an authURL


### PR DESCRIPTION
For many oidc providers, the client_secret is actually not required.
Specifically, you can set keycloak clients to be optionally 'authorized' using a client secret.  In ADFS, only the 'server application' allows client_secret, trying to use native app or web api doesn't have client_secret, and subsequently throws errors if you try to send one.
This change makes the client secret optional.