### PR TITLE
Add support to pass tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ server {
 
       # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
       auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+      
+      # optionally add X-Vouch-IdP-Claims-* custom claims you are tracking
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
 
       # these return values are used by the @error401 call
       auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
@@ -81,11 +85,16 @@ server {
     location / {
       # forward authorized requests to your service protectedapp.yourdomain.com
       proxy_pass http://127.0.0.1:8080;
-      # you may need to set
+      # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
       #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      # in this bock as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+
       # set user header (usually an email)
       proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
+      # Pass any other custom claims you are tracking
+      # proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+      # proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ server {
 
       # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
       auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
-      
+
       # optionally add X-Vouch-IdP-Claims-* custom claims you are tracking
       #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
       #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+      # optinally add X-Vouch-IdP-AccessToken or X-Vouch-IdP-IdToken
+      #    auth_request_set $auth_resp_x_vouch_idp_accesstoken $upstream_http_x_vouch_idp_accesstoken;
+      #    auth_request_set $auth_resp_x_vouch_idp_idtoken $upstream_http_x_vouch_idp_idtoken;
 
       # these return values are used by the @error401 call
       auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
@@ -92,9 +95,12 @@ server {
 
       # set user header (usually an email)
       proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
-      # Pass any other custom claims you are tracking
-      # proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
-      # proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+      # optionally pass any custom claims you are tracking
+      #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+      #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+      # optionally pass the accesstoken or idtoken
+      #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
+      #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
     }
 }
 

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -77,6 +77,19 @@ vouch:
     jwt: X-Vouch-Token
     querystring: access_token
     redirect: X-Vouch-Requested-URI
+    # Claims is a list of claims that will be stored in the JWT and passed down to applications via headers
+    # By default claims are sent down as headers with a prefix of X-Vouch-IdP-Claims-ClaimKey
+    # Only when a claim is found in the user's info will the header exist.  This is optional.  These are case sensitive.
+    claims:
+      - groups
+      - given_name
+    # these will result in two headers being passed back to nginx
+    # X-Vouch-IdP-Claims-groups
+    # X-Vouch-IdP-Claims-given_name
+      
+    # Customizable claim header. 
+    # claimheader: My-Custom-Claim-Prefix
+
 
   db: 
     file: data/vouch_bolt.db

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -8,10 +8,15 @@
 vouch:
   # logLevel: debug
   logLevel: info
+
+  # testing - force all 302 redirects to be rendered as a webpage with a link
+  # if you're having problems, turn on testing
+  testing: true
+
   listen: 0.0.0.0
   port: 9090
 
-  # domains:
+  # domains -
   # each of these domains must serve the url https://vouch.$domains[0] https://vouch.$domains[1] ...
   # so that the cookie which stores the JWT can be set in the relevant domain
   # you usually *don't* want to list every individual website that will be protected
@@ -31,7 +36,7 @@ vouch:
   # You will need to direct people to the Vouch Proxy login page from your application.
   # publicAccess: false
 
-  # whiteList (optional) allows only the listed usernames
+  # whiteList - (optional) allows only the listed usernames
   # usernames are usually email addresses (google, most oidc providers) or login/username for github and github enterprise
   whiteList:
   - bob@yourdomain.com
@@ -39,7 +44,7 @@ vouch:
   - joe@yourdomain.com
 
   jwt:
-    # secret: a random string used to cryptographically sign the jwt
+    # secret - a random string used to cryptographically sign the jwt
     # Vouch Proxy complains if the string is less than 44 characters (256 bits as 32 base64 bytes)
     # if the secret is not set here then..
     # look for the secret in `./config/secret`
@@ -66,7 +71,7 @@ vouch:
   session:
     # name of session variable stored locally
     name: VouchSession
-    # key: a cryptographic string used to store the session variable
+    # key - a cryptographic string used to store the session variable
     # if the key is not set here then it is generated at startup and stored in memory
     # Vouch Proxy complains if the string is less than 44 characters (256 bits as 32 base64 bytes)
     # you only want to set this if you're running multiple user facing vouch.yourdomain.com instances
@@ -77,7 +82,8 @@ vouch:
     jwt: X-Vouch-Token
     querystring: access_token
     redirect: X-Vouch-Requested-URI
-    # Claims is a list of claims that will be stored in the JWT and passed down to applications via headers
+
+    # claims - a list of claims that will be stored in the JWT and passed down to applications via headers
     # By default claims are sent down as headers with a prefix of X-Vouch-IdP-Claims-ClaimKey
     # Only when a claim is found in the user's info will the header exist.  This is optional.  These are case sensitive.
     claims:
@@ -87,19 +93,23 @@ vouch:
     # X-Vouch-IdP-Claims-groups
     # X-Vouch-IdP-Claims-given_name
       
-    # Customizable claim header. 
+    # claimheader - Customizable claim header prefix (instead of default `X-Vouch-IdP-Claims-`) 
     # claimheader: My-Custom-Claim-Prefix
 
+    # accesstoken - Pass the user's access token from the provider.  This is useful if you need to pass the IdP token to a downstream
+    # application. This is optional.
+    # accesstoken: X-Vouch-IdP-AccessToken
+    # idtoken - Pass the user's Id token from the provider.  This is useful if you need to pass this token to a downstream
+    # application. This is optional.
+    # idtoken: X-Vouch-IdP-IdToken
 
   db: 
     file: data/vouch_bolt.db
 
-  # testing: force all 302 redirects to be rendered as a webpage with a link
-  testing: true
-  # test_url: add this URL to the page which vouch displays
+  # test_url - add this URL to the page which vouch displays
   test_url: http://yourdomain.com
-  # webapp: WIP for web interface to vouch (mostly logs)
-  webapp: true
+  # webapp - WIP for web interface to vouch (mostly logs)
+  # webapp: true
 
 #
 # OAuth Provider

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -83,6 +83,15 @@ vouch:
     querystring: access_token
     redirect: X-Vouch-Requested-URI
 
+    # GENERAL WARNING ABOUT claims AND tokens
+    # all of these config elements can cause performance impacts due to the amount of information being 
+    # moved around.  They will get added to the Vouch cookie and (possibly) make it large.  The Vouch cookie will 
+    # get split up into several cookies. Every request will process the cookies in order to extract and create the 
+    # additional headers which get returned.  But if you need it, you need it.
+    # With large cookies and headers it will require additional nginx config to open up the buffers a bit..
+    # see `large_client_header_buffers` http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
+    # and `proxy_buffer_size` http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size
+
     # claims - a list of claims that will be stored in the JWT and passed down to applications via headers
     # By default claims are sent down as headers with a prefix of X-Vouch-IdP-Claims-ClaimKey
     # Only when a claim is found in the user's info will the header exist.  This is optional.  These are case sensitive.

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -666,8 +666,9 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *stru
 	formData.Set("resource", cfg.GenOAuth.RedirectURL)
 	formData.Set("client_id", cfg.GenOAuth.ClientID)
 	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
-	formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
-
+	if cfg.GenOAuth.ClientSecret != "" {
+		formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
+	}
 	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
 	if err != nil {
 		return err

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -228,7 +228,6 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add(cfg.Cfg.Headers.User, claims.Username)
 	w.Header().Add(cfg.Cfg.Headers.Success, "true")
 
-	log.Debugf("response header %+v", w.Header())
 	if cfg.Cfg.Headers.AccessToken != "" {
 		if claims.PAccessToken != "" {
 			w.Header().Add(cfg.Cfg.Headers.AccessToken, claims.PAccessToken)
@@ -240,8 +239,11 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 
 		}
 	}
+	// fastlog.Debugf("response headers %+v", w.Header())
+	// fastlog.Debug("response header",
+	// 	zap.String(cfg.Cfg.Headers.User, w.Header().Get(cfg.Cfg.Headers.User)))
 	fastlog.Debug("response header",
-		zap.String(cfg.Cfg.Headers.User, w.Header().Get(cfg.Cfg.Headers.User)))
+		zap.Any("all headers", w.Header()))
 
 	// good to go!!
 	if cfg.Cfg.Testing {
@@ -523,6 +525,7 @@ func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.Cust
 	}
 	ptokens.PAccessToken = providerToken.AccessToken
 	ptokens.PIdToken = providerToken.Extra("id_token").(string)
+	log.Debugf("ptokens: %+v", ptokens)
 
 	// make the "third leg" request back to google to exchange the token for the userinfo
 	client := cfg.OAuthClient.Client(context.TODO(), providerToken)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -196,20 +196,25 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(cfg.Cfg.Headers.Claims) > 0 {
+		log.Debug("Found claims in config, finding specific keys...")
 		// Run through all the claims found
 		for k, v := range claims.CustomClaims {
 			// Run through the claims we are looking for
 			for _, cv := range cfg.Cfg.Headers.Claims {
 				// Check for matching claim
 				if cv == k {
+					log.Debug("Found matching claim key: ", k)
+					customHeader := strings.Join([]string{cfg.Cfg.Headers.ClaimHeader, k}, "")
 					if val, ok := v.(string); ok {
-						w.Header().Add(cfg.Cfg.Headers.ClaimHeader, val)
+						w.Header().Add(customHeader, val)
+						log.Debug("Adding header for claim: ", k, " Name: ", customHeader, " Value: ", val)
 					} else if val, ok := v.([]interface{}); ok {
 						strs := make([]string, len(val))
 						for i, v := range val {
 							strs[i] = fmt.Sprintf("\"%s\"", v)
 						}
-						w.Header().Add(cfg.Cfg.Headers.ClaimHeader, strings.Join(strs, ","))
+						log.Debug("Adding header for claim: ", k, " Name: ", customHeader, " Value: ", strings.Join(strs, ","))
+						w.Header().Add(customHeader, strings.Join(strs, ","))
 					} else {
 						log.Error("Couldn't parse header type.  Please submit an issue.")
 					}
@@ -220,8 +225,7 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add(cfg.Cfg.Headers.User, claims.Username)
 	w.Header().Add(cfg.Cfg.Headers.Success, "true")
-	fastlog.Debug("response header",
-		zap.String(cfg.Cfg.Headers.User, w.Header().Get(cfg.Cfg.Headers.User)))
+	log.Debugf("response header %+v", w.Header())
 
 	// good to go!!
 	if cfg.Cfg.Testing {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -423,7 +423,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	model.PutUser(user)
 
 	// issue the jwt
-	tokenstring := jwtmanager.CreateUserTokenString(user)
+	tokenstring := jwtmanager.CreateUserTokenString(user, customClaims)
 	cookie.SetCookie(w, r, tokenstring)
 
 	// get the originally requested URL so we can send them on their way

--- a/main.go
+++ b/main.go
@@ -55,23 +55,23 @@ func main() {
 		"listen", listen,
 		"oauth.provider", cfg.GenOAuth.Provider)
 
-	mux := mux.NewRouter()
+	theMux := mux.NewRouter()
 
 	authH := http.HandlerFunc(handlers.ValidateRequestHandler)
-	mux.HandleFunc("/validate", timelog.TimeLog(authH))
-	mux.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
+	theMux.HandleFunc("/validate", timelog.TimeLog(authH))
+	theMux.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
 
 	loginH := http.HandlerFunc(handlers.LoginHandler)
-	mux.HandleFunc("/login", timelog.TimeLog(loginH))
+	theMux.HandleFunc("/login", timelog.TimeLog(loginH))
 
 	logoutH := http.HandlerFunc(handlers.LogoutHandler)
-	mux.HandleFunc("/logout", timelog.TimeLog(logoutH))
+	theMux.HandleFunc("/logout", timelog.TimeLog(logoutH))
 
 	callH := http.HandlerFunc(handlers.CallbackHandler)
-	mux.HandleFunc("/auth", timelog.TimeLog(callH))
+	theMux.HandleFunc("/auth", timelog.TimeLog(callH))
 
 	healthH := http.HandlerFunc(handlers.HealthcheckHandler)
-	mux.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
+	theMux.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
 
 	if logger.Desugar().Core().Enabled(zap.DebugLevel) {
 		path, err := filepath.Abs(staticDir)
@@ -81,20 +81,20 @@ func main() {
 		logger.Debugf("serving static files from %s", path)
 	}
 	// https://golangcode.com/serve-static-assets-using-the-mux-router/
-	mux.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, (http.FileServer(http.Dir("." + staticDir)))))
+	theMux.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
 
 	if cfg.Cfg.WebApp {
 		logger.Info("enabling websocket")
 		tran.ExplicitInit()
-		mux.Handle("/ws", tran.WS)
+		theMux.Handle("/ws", tran.WS)
 	}
 
 	// socketio := tran.NewServer()
-	// mux.Handle("/socket.io/", cors.AllowAll(socketio))
+	// theMux.Handle("/socket.io/", cors.AllowAll(socketio))
 	// http.Handle("/socket.io/", tran.Server)
 
 	srv := &http.Server{
-		Handler: mux,
+		Handler: theMux,
 		Addr:    listen,
 		// Good practice: enforce timeouts for servers you create!
 		WriteTimeout: 15 * time.Second,

--- a/main.go
+++ b/main.go
@@ -55,23 +55,23 @@ func main() {
 		"listen", listen,
 		"oauth.provider", cfg.GenOAuth.Provider)
 
-	theMux := mux.NewRouter()
+	muxR := mux.NewRouter()
 
 	authH := http.HandlerFunc(handlers.ValidateRequestHandler)
-	theMux.HandleFunc("/validate", timelog.TimeLog(authH))
-	theMux.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
+	muxR.HandleFunc("/validate", timelog.TimeLog(authH))
+	muxR.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
 
 	loginH := http.HandlerFunc(handlers.LoginHandler)
-	theMux.HandleFunc("/login", timelog.TimeLog(loginH))
+	muxR.HandleFunc("/login", timelog.TimeLog(loginH))
 
 	logoutH := http.HandlerFunc(handlers.LogoutHandler)
-	theMux.HandleFunc("/logout", timelog.TimeLog(logoutH))
+	muxR.HandleFunc("/logout", timelog.TimeLog(logoutH))
 
 	callH := http.HandlerFunc(handlers.CallbackHandler)
-	theMux.HandleFunc("/auth", timelog.TimeLog(callH))
+	muxR.HandleFunc("/auth", timelog.TimeLog(callH))
 
 	healthH := http.HandlerFunc(handlers.HealthcheckHandler)
-	theMux.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
+	muxR.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
 
 	if logger.Desugar().Core().Enabled(zap.DebugLevel) {
 		path, err := filepath.Abs(staticDir)
@@ -81,20 +81,20 @@ func main() {
 		logger.Debugf("serving static files from %s", path)
 	}
 	// https://golangcode.com/serve-static-assets-using-the-mux-router/
-	theMux.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
+	muxR.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
 
 	if cfg.Cfg.WebApp {
 		logger.Info("enabling websocket")
 		tran.ExplicitInit()
-		theMux.Handle("/ws", tran.WS)
+		muxR.Handle("/ws", tran.WS)
 	}
 
 	// socketio := tran.NewServer()
-	// theMux.Handle("/socket.io/", cors.AllowAll(socketio))
+	// muxR.Handle("/socket.io/", cors.AllowAll(socketio))
 	// http.Handle("/socket.io/", tran.Server)
 
 	srv := &http.Server{
-		Handler: theMux,
+		Handler: muxR,
 		Addr:    listen,
 		// Good practice: enforce timeouts for servers you create!
 		WriteTimeout: 15 * time.Second,

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -51,7 +51,7 @@ type config struct {
 		QueryString string   `mapstructure:"querystring"`
 		Redirect    string   `mapstructure:"redirect"`
 		Success     string   `mapstructure:"success"`
-		claimHeader string   `mapstructure:"claimheader"`
+		ClaimHeader string   `mapstructure:"claimheader"`
 		Claims      []string `mapstructure:"claims"`
 	}
 	DB struct {
@@ -459,6 +459,9 @@ func SetDefaults() {
 	}
 	if !viper.IsSet(Branding.LCName + ".headers.success") {
 		Cfg.Headers.Success = "X-" + Branding.CcName + "-Success"
+	}
+	if !viper.IsSet(Branding.LCName + ".headers.claimheader") {
+		Cfg.Headers.ClaimHeader = "X-" + Branding.CcName + "-IdP-Claims-"
 	}
 
 	// db defaults

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -44,14 +44,14 @@ type config struct {
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 		MaxAge   int    `mapstructure:"maxage"`
 	}
-	Claims  []string `mapstructure:"claims"`
+
 	Headers struct {
-		JWT         string `mapstructure:"jwt"`
-		User        string `mapstructure:"user"`
-		QueryString string `mapstructure:"querystring"`
-		Redirect    string `mapstructure:"redirect"`
-		Success     string `mapstructure:"success"`
-		Claims      string `mapstructure:"claims"`
+		JWT         string   `mapstructure:"jwt"`
+		User        string   `mapstructure:"user"`
+		QueryString string   `mapstructure:"querystring"`
+		Redirect    string   `mapstructure:"redirect"`
+		Success     string   `mapstructure:"success"`
+		Claims      []string `mapstructure:"claims"`
 	}
 	DB struct {
 		File string `mapstructure:"file"`

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -51,6 +51,7 @@ type config struct {
 		QueryString string   `mapstructure:"querystring"`
 		Redirect    string   `mapstructure:"redirect"`
 		Success     string   `mapstructure:"success"`
+		claimHeader string   `mapstructure:"claimheader"`
 		Claims      []string `mapstructure:"claims"`
 	}
 	DB struct {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -224,7 +224,9 @@ func setDevelopmentLogger() {
 
 // InitForTestPurposes is called by most *_testing.go files in Vouch Proxy
 func InitForTestPurposes() {
-	os.Setenv(Branding.UCName+"_CONFIG", "../../config/test_config.yml")
+	if err := os.Setenv(Branding.UCName+"_CONFIG", "../../config/test_config.yml"); err != nil {
+		log.Error(err)
+	}
 	// log.Debug("opening config")
 	setDevelopmentLogger()
 	ParseConfig()
@@ -255,17 +257,16 @@ func ParseConfig() {
 		log.Fatalf("Fatal error config file: %s", err.Error())
 		panic(err)
 	}
-	err = UnmarshalKey(Branding.LCName, &Cfg)
-	if err != nil {
-		log.Errorf("Couldn't unmarshal configuration")
+	if err = UnmarshalKey(Branding.LCName, &Cfg); err != nil {
+		log.Error(err)
 	}
 	if len(Cfg.Domains) == 0 {
 		// then lets check for "lasso"
 		var oldConfig config
-		err = UnmarshalKey(Branding.OldLCName, &oldConfig)
-		if err != nil {
-			log.Errorf("Couldn't unmarshal configuration")
+		if err = UnmarshalKey(Branding.OldLCName, &oldConfig); err != nil {
+			log.Error(err)
 		}
+
 		if len(oldConfig.Domains) != 0 {
 			log.Errorf(`						
 
@@ -601,6 +602,8 @@ func isTCPPortAvailable(listen string) bool {
 		log.Error(err)
 		return false
 	}
-	conn.Close()
+	if err = conn.Close(); err != nil {
+		log.Error(err)
+	}
 	return true
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -53,6 +53,8 @@ type config struct {
 		Success     string   `mapstructure:"success"`
 		ClaimHeader string   `mapstructure:"claimheader"`
 		Claims      []string `mapstructure:"claims"`
+		AccessToken string   `mapstructure:"accesstoken"`
+		IDToken     string   `mapstructure:"idtoken"`
 	}
 	DB struct {
 		File string `mapstructure:"file"`

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -44,12 +44,14 @@ type config struct {
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 		MaxAge   int    `mapstructure:"maxage"`
 	}
+	Claims  []string `mapstructure:"claims"`
 	Headers struct {
 		JWT         string `mapstructure:"jwt"`
 		User        string `mapstructure:"user"`
 		QueryString string `mapstructure:"querystring"`
 		Redirect    string `mapstructure:"redirect"`
 		Success     string `mapstructure:"success"`
+		Claims      string `mapstructure:"claims"`
 	}
 	DB struct {
 		File string `mapstructure:"file"`
@@ -252,11 +254,17 @@ func ParseConfig() {
 		log.Fatalf("Fatal error config file: %s", err.Error())
 		panic(err)
 	}
-	UnmarshalKey(Branding.LCName, &Cfg)
+	err = UnmarshalKey(Branding.LCName, &Cfg)
+	if err != nil {
+		log.Errorf("Couldn't unmarshal configuration")
+	}
 	if len(Cfg.Domains) == 0 {
 		// then lets check for "lasso"
 		var oldConfig config
-		UnmarshalKey(Branding.OldLCName, &oldConfig)
+		err = UnmarshalKey(Branding.OldLCName, &oldConfig)
+		if err != nil {
+			log.Errorf("Couldn't unmarshal configuration")
+		}
 		if len(oldConfig.Domains) != 0 {
 			log.Errorf(`						
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -308,8 +308,9 @@ func BasicTest() error {
 	case GenOAuth.ClientID == "":
 		// everyone has a clientID
 		return errors.New("configuration error: oauth.client_id not found")
-	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.ClientSecret == "":
+	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.ADFS && GenOAuth.Provider != Providers.OIDC && GenOAuth.ClientSecret == "":
 		// everyone except IndieAuth has a clientSecret
+		// ADFS and OIDC providers also do not require this, but can have it optionally set.
 		return errors.New("configuration error: o`auth.client_secret not found")
 	case GenOAuth.Provider != Providers.Google && GenOAuth.AuthURL == "":
 		// everyone except IndieAuth and Google has an authURL

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -2,7 +2,10 @@ package cookie
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
+	"unicode/utf8"
 
 	// "github.com/vouch/vouch-proxy/pkg/structs"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
@@ -17,6 +20,7 @@ func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
 }
 
 func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
+	cookieName := cfg.Cfg.Cookie.Name
 	// foreach domain
 	domain := domains.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
@@ -24,10 +28,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		domain = cfg.Cfg.Cookie.Domain
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
-	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
-	// Cookies get deleted after the current session (when the browser closes) when no expires or maxage setting is set,
-	// or when expires is set to 0.
-	http.SetCookie(w, &http.Cookie{
+	cookie := http.Cookie{
 		Name:     cfg.Cfg.Cookie.Name,
 		Value:    val,
 		Path:     "/",
@@ -35,27 +36,126 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		MaxAge:   maxAge,
 		Secure:   cfg.Cfg.Cookie.Secure,
 		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
-	})
+	}
+	cookieSize := len(cookie.String())
+	cookie.Value = ""
+	emptyCookieSize := len(cookie.String())
+	// Cookies have a max size of 4096 bytes, but to support most browsers, we should stay below 4000 bytes
+	// https://tools.ietf.org/html/rfc6265#section-6.1
+	// http://browsercookielimits.squawky.net/
+	if cookieSize > 4000 {
+		// https://www.lifewire.com/cookie-limit-per-domain-3466809
+		log.Warnf("cookie size: %d.  cookie sizes over ~4093 bytes(depending on the browser and platform) have shown to cause issues or simply aren't supported.", cookieSize)
+		cookieParts := SplitCookie(val, 4000-emptyCookieSize)
+		for i, cookiePart := range cookieParts {
+			if i > 0 {
+				cookieName = fmt.Sprintf("%s%d", cfg.Cfg.Cookie.Name, i)
+			} else {
+				cookieName = cfg.Cfg.Cookie.Name
+			}
+			// Cookies are named with adding 1, 2, 3, etc after the original name per part.
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookieName,
+				Value:    cookiePart,
+				Path:     "/",
+				Domain:   domain,
+				MaxAge:   maxAge,
+				Secure:   cfg.Cfg.Cookie.Secure,
+				HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+			})
+		}
+	} else {
+		http.SetCookie(w, &http.Cookie{
+			Name:     cookieName,
+			Value:    val,
+			Path:     "/",
+			Domain:   domain,
+			MaxAge:   maxAge,
+			Secure:   cfg.Cfg.Cookie.Secure,
+			HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+		})
+	}
 }
 
 // Cookie get the vouch jwt cookie
 func Cookie(r *http.Request) (string, error) {
-	cookie, err := r.Cookie(cfg.Cfg.Cookie.Name)
-	if err != nil {
-		return "", err
+	var err error
+	cookies := r.Cookies()
+	var combinedCookie strings.Builder
+	// Get the remaining parts
+	for i := 0; i <= len(cookies); i++ {
+		// search for cookie parts in order
+		for _, cookie := range cookies {
+			// Find the first cookie part
+			if i == 0 {
+				if cookie.Name == cfg.Cfg.Cookie.Name {
+					log.Debugw("cookie",
+						"cookieName", cookie.Name,
+						"cookieValue", cookie.Value,
+					)
+					combinedCookie.WriteString(cookie.Value)
+					break
+				}
+			} else {
+				// Get the remaining parts
+				if cookie.Name == fmt.Sprintf("%s%d", cfg.Cfg.Cookie.Name, i) {
+					log.Debugw("cookie",
+						"cookieName", cookie.Name,
+						"cookieValue", cookie.Value,
+					)
+					combinedCookie.WriteString(cookie.Value)
+					break
+				}
+			}
+		}
 	}
-	if cookie.Value == "" {
+	combinedCookieStr := combinedCookie.String()
+	if combinedCookieStr == "" {
 		return "", errors.New("Cookie token empty")
 	}
 
-	log.Debugw("cookie",
-		"cookieName", cfg.Cfg.Cookie.Name,
-		"cookieValue", cookie.Value,
+	log.Debugw("combined cookie",
+		"cookieValue", combinedCookieStr,
 	)
-	return cookie.Value, err
+	return combinedCookieStr, err
 }
 
 // ClearCookie get rid of the existing cookie
 func ClearCookie(w http.ResponseWriter, r *http.Request) {
-	setCookie(w, r, "delete", -1)
+	cookies := r.Cookies()
+	domain := domains.Matches(r.Host)
+	// Allow overriding the cookie domain in the config file
+	if cfg.Cfg.Cookie.Domain != "" {
+		domain = cfg.Cfg.Cookie.Domain
+		log.Debugf("setting the cookie domain to %v", domain)
+	}
+	// search for cookie parts
+	for _, cookie := range cookies {
+		if strings.HasPrefix(cookie.Name, cfg.Cfg.Cookie.Name) {
+			log.Debugf("deleting cookie: %s", cookie.Name)
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookie.Name,
+				Value:    "delete",
+				Path:     "/",
+				Domain:   domain,
+				MaxAge:   -1,
+				Secure:   cfg.Cfg.Cookie.Secure,
+				HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+			})
+		}
+	}
+}
+
+func SplitCookie(longString string, maxLen int) []string {
+	splits := []string{}
+
+	var l, r int
+	for l, r = 0, maxLen; r < len(longString); l, r = r, r+maxLen {
+		for !utf8.RuneStart(longString[r]) {
+			r--
+		}
+		splits = append(splits, longString[l:r])
+	}
+	splits = append(splits, longString[l:])
+	return splits
 }

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -80,7 +80,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 func Cookie(r *http.Request) (string, error) {
 
 	var cookieParts []string
-	var numParts int = -1
+	var numParts = -1
 
 	var err error
 	cookies := r.Cookies()
@@ -102,13 +102,14 @@ func Cookie(r *http.Request) (string, error) {
 				if numParts, err = strconv.Atoi(xyArray[1]); err != nil {
 					return "", fmt.Errorf("multipart cookie fail: %s", err)
 				}
+				log.Debugf("make cookieParts of size %d", numParts)
 				cookieParts = make([]string, numParts)
 			}
 			var i int
 			if i, err = strconv.Atoi(xyArray[0]); err != nil {
 				return "", fmt.Errorf("multipart cookie fail: %s", err)
 			}
-			cookieParts[i] = cookie.Value
+			cookieParts[i-1] = cookie.Value
 		}
 
 	}

--- a/pkg/cookie/cookie_test.go
+++ b/pkg/cookie/cookie_test.go
@@ -1,0 +1,27 @@
+package cookie
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitCookie(t *testing.T) {
+	type args struct {
+		longString string
+		maxLen     int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"small split", args{"AAAbbbCCCdddEEEfffGGGhhhIIIjjj", 3}, []string{"AAA", "bbb", "CCC", "ddd", "EEE", "fff", "GGG", "hhh", "III", "jjj"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SplitCookie(tt.args.longString, tt.args.maxLen); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitCookie() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -26,7 +26,7 @@ type VouchClaims struct {
 	jwt.StandardClaims
 }
 
-// StandardClaims jwt.StandardClaims implimentation
+// StandardClaims jwt.StandardClaims implementation
 var StandardClaims jwt.StandardClaims
 
 // CustomClaims implementation

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -23,6 +23,8 @@ type VouchClaims struct {
 	Username     string   `json:"username"`
 	Sites        []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
 	CustomClaims map[string]interface{}
+	PAccessToken string
+	PIdToken     string
 	jwt.StandardClaims
 }
 
@@ -54,13 +56,15 @@ func populateSites() {
 }
 
 // CreateUserTokenString converts user to signed jwt
-func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims) string {
+func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims, ptokens structs.PTokens) string {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
 		u.Username,
 		Sites,
 		customClaims.Claims,
+		ptokens.PAccessToken,
+		ptokens.PIdToken,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -54,13 +54,13 @@ func populateSites() {
 }
 
 // CreateUserTokenString converts user to signed jwt
-func CreateUserTokenString(u structs.User) string {
+func CreateUserTokenString(u structs.User, customClaims map[string]interface{}) string {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
 		u.Username,
 		Sites,
-		CustomClaims,
+		customClaims,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -20,13 +20,17 @@ import (
 
 // VouchClaims jwt Claims specific to vouch
 type VouchClaims struct {
-	Username string   `json:"username"`
-	Sites    []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
+	Username     string   `json:"username"`
+	Sites        []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
+	CustomClaims map[string]interface{}
 	jwt.StandardClaims
 }
 
 // StandardClaims jwt.StandardClaims implimentation
 var StandardClaims jwt.StandardClaims
+
+// CustomClaims implementation
+var CustomClaims map[string]interface{}
 
 // Sites added to VouchClaims
 var Sites []string
@@ -56,6 +60,7 @@ func CreateUserTokenString(u structs.User) string {
 	claims := VouchClaims{
 		u.Username,
 		Sites,
+		CustomClaims,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -54,13 +54,13 @@ func populateSites() {
 }
 
 // CreateUserTokenString converts user to signed jwt
-func CreateUserTokenString(u structs.User, customClaims map[string]interface{}) string {
+func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims) string {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
 		u.Username,
 		Sites,
-		customClaims,
+		customClaims.Claims,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -2,9 +2,10 @@ package jwtmanager
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,6 +14,10 @@ var (
 	u1 = structs.User{
 		Username: "test@testing.com",
 		Name:     "Test Name",
+	}
+	t1 = structs.PTokens{
+		PAccessToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjRvaXU4In0.eyJzdWIiOiJuZnlmZSIsImF1ZCI6ImltX29pY19jbGllbnQiLCJqdGkiOiJUOU4xUklkRkVzUE45enU3ZWw2eng2IiwiaXNzIjoiaHR0cHM6XC9cL3Nzby5tZXljbG91ZC5uZXQ6OTAzMSIsImlhdCI6MTM5MzczNzA3MSwiZXhwIjoxMzkzNzM3MzcxLCJub25jZSI6ImNiYTU2NjY2LTRiMTItNDU2YS04NDA3LTNkMzAyM2ZhMTAwMiIsImF0X2hhc2giOiJrdHFvZVBhc2praVY5b2Z0X3o5NnJBIn0.g1Jc9DohWFfFG3ppWfvW16ib6YBaONC5VMs8J61i5j5QLieY-mBEeVi1D3vr5IFWCfivY4hZcHtoJHgZk1qCumkAMDymsLGX-IGA7yFU8LOjUdR4IlCPlZxZ_vhqr_0gQ9pCFKDkiOv1LVv5x3YgAdhHhpZhxK6rWxojg2RddzvZ9Xi5u2V1UZ0jukwyG2d4PRzDn7WoRNDGwYOEt4qY7lv_NO2TY2eAklP-xYBWu0b9FBElapnstqbZgAXdndNs-Wqp4gyQG5D0owLzxPErR9MnpQfgNcai-PlWI_UrvoopKNbX0ai2zfkuQ-qh6Xn8zgkiaYDHzq4gzwRfwazaqA",
+		PIdToken:     "eyJhbGciOiJSUzI1NiIsImtpZCI6IjRvaXU4In0.eyJzdWIiOiJuZnlmZSIsImF1ZCI6ImltX29pY19jbGllbnQiLCJqdGkiOiJUOU4xUklkRkVzUE45enU3ZWw2eng2IiwiaXNzIjoiaHR0cHM6XC9cL3Nzby5tZXljbG91ZC5uZXQ6OTAzMSIsImlhdCI6MTM5MzczNzA3MSwiZXhwIjoxMzkzNzM3MzcxLCJub25jZSI6ImNiYTU2NjY2LTRiMTItNDU2YS04NDA3LTNkMzAyM2ZhMTAwMiIsImF0X2hhc2giOiJrdHFvZVBhc2praVY5b2Z0X3o5NnJBIn0.g1Jc9DohWFfFG3ppWfvW16ib6YBaONC5VMs8J61i5j5QLieY-mBEeVi1D3vr5IFWCfivY4hZcHtoJHgZk1qCumkAMDymsLGX-IGA7yFU8LOjUdR4IlCPlZxZ_vhqr_0gQ9pCFKDkiOv1LVv5x3YgAdhHhpZhxK6rWxojg2RddzvZ9Xi5u2V1UZ0jukwyG2d4PRzDn7WoRNDGwYOEt4qY7lv_NO2TY2eAklP-xYBWu0b9FBElapnstqbZgAXdndNs-Wqp4gyQG5D0owLzxPErR9MnpQfgNcai-PlWI_UrvoopKNbX0ai2zfkuQ-qh6Xn8zgkiaYDHzq4gzwRfwazaqA",
 	}
 
 	lc VouchClaims
@@ -36,6 +41,8 @@ func init() {
 		u1.Username,
 		Sites,
 		customClaims.Claims,
+		t1.PAccessToken,
+		t1.PIdToken,
 		StandardClaims,
 	}
 	json.Unmarshal([]byte(claimjson), &customClaims.Claims)
@@ -43,7 +50,7 @@ func init() {
 
 func TestCreateUserTokenStringAndParseToUsername(t *testing.T) {
 
-	uts := CreateUserTokenString(u1, customClaims)
+	uts := CreateUserTokenString(u1, customClaims, t1)
 	assert.NotEmpty(t, uts)
 
 	utsParsed, err := ParseTokenString(uts)
@@ -68,7 +75,7 @@ func TestClaims(t *testing.T) {
 	// log.Infof("lc d %s", d.String())
 	// lc.StandardClaims.ExpiresAt = now.Add(time.Duration(ExpiresAtMinutes) * time.Minute).Unix()
 	// log.Infof("lc expiresAt %d", now.Unix()-lc.StandardClaims.ExpiresAt)
-	uts := CreateUserTokenString(u1, customClaims)
+	uts := CreateUserTokenString(u1, customClaims, t1)
 	utsParsed, _ := ParseTokenString(uts)
 	log.Infof("utsParsed: %+v", utsParsed)
 	log.Infof("Sites: %+v", Sites)

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -1,10 +1,10 @@
 package jwtmanager
 
 import (
-	"testing"
-
+	"encoding/json"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,6 +16,15 @@ var (
 	}
 
 	lc VouchClaims
+
+	claimjson = `{
+		"sub": "f:a95afe53-60ba-4ac6-af15-fab870e72f3d:mrtester",
+		"groups": ["Website Users", "Test Group"],
+		"given_name": "Mister",
+		"family_name": "Tester",
+		"email": "mrtester@test.int"
+	}`
+	customClaims = structs.CustomClaims{}
 )
 
 func init() {
@@ -26,13 +35,15 @@ func init() {
 	lc = VouchClaims{
 		u1.Username,
 		Sites,
+		customClaims.Claims,
 		StandardClaims,
 	}
+	json.Unmarshal([]byte(claimjson), &customClaims.Claims)
 }
 
 func TestCreateUserTokenStringAndParseToUsername(t *testing.T) {
 
-	uts := CreateUserTokenString(u1)
+	uts := CreateUserTokenString(u1, customClaims)
 	assert.NotEmpty(t, uts)
 
 	utsParsed, err := ParseTokenString(uts)
@@ -57,7 +68,7 @@ func TestClaims(t *testing.T) {
 	// log.Infof("lc d %s", d.String())
 	// lc.StandardClaims.ExpiresAt = now.Add(time.Duration(ExpiresAtMinutes) * time.Minute).Unix()
 	// log.Infof("lc expiresAt %d", now.Unix()-lc.StandardClaims.ExpiresAt)
-	uts := CreateUserTokenString(u1)
+	uts := CreateUserTokenString(u1, customClaims)
 	utsParsed, _ := ParseTokenString(uts)
 	log.Infof("utsParsed: %+v", utsParsed)
 	log.Infof("Sites: %+v", Sites)

--- a/pkg/model/site.go
+++ b/pkg/model/site.go
@@ -69,13 +69,17 @@ func AllSites(sites *[]structs.Site) error {
 	return Db.View(func(tx *bolt.Tx) error {
 		if b := tx.Bucket(siteBucket); b != nil {
 			// c := b.Cursor()
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				log.Debugf("key=%s, value=%s\n", k, v)
 				s := structs.Site{}
-				Site(k, &s)
+				if err := Site(k, &s); err != nil {
+					log.Error(err)
+				}
 				*sites = append(*sites, s)
 				return nil
-			})
+			}); err != nil {
+				log.Error(err)
+			}
 			log.Debugf("sites %v", sites)
 		}
 		return nil

--- a/pkg/model/team.go
+++ b/pkg/model/team.go
@@ -83,13 +83,17 @@ func DeleteTeam(t structs.Team) error {
 func AllTeams(teams *[]structs.Team) error {
 	return Db.View(func(tx *bolt.Tx) error {
 		if b := tx.Bucket(teamBucket); b != nil {
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				log.Debugf("AllTeams ForEach key %s", k)
 				t := structs.Team{}
-				Team(k, &t)
+				if err := Team(k, &t); err != nil {
+					log.Error(err)
+				}
 				*teams = append(*teams, t)
 				return nil
-			})
+			}); err != nil {
+				log.Error(err)
+			}
 			log.Debugf("teams %+v", *teams)
 			return nil
 		}

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -81,13 +81,17 @@ func User(key []byte, u *structs.User) error {
 func AllUsers(users *[]structs.User) error {
 	return Db.View(func(tx *bolt.Tx) error {
 		if b := tx.Bucket(userBucket); b != nil {
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				log.Debugf("key=%s, value=%s\n", k, v)
 				u := structs.User{}
-				User(k, &u)
+				if err := User(k, &u); err != nil {
+					log.Error(err)
+				}
 				*users = append(*users, u)
 				return nil
-			})
+			}); err != nil {
+				log.Error(err)
+			}
 			log.Debugf("users %v", users)
 			return nil
 		}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -1,5 +1,10 @@
 package structs
 
+// Temporary struct storing custom claims until JWT creation.
+type CustomClaims struct {
+	Claims map[string]interface{}
+}
+
 // UserI each *User struct must prepare the data for being placed in the JWT
 type UserI interface {
 	PrepareUserData()

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -110,3 +110,8 @@ type Site struct {
 	LastUpdate int64  `json:"lastupdate"`
 	ID         int    `json:"id" mapstructure:"id"`
 }
+
+type PTokens struct {
+	PAccessToken string
+	PIdToken     string
+}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -15,12 +15,12 @@ type User struct {
 	// TODO: set Provider here so that we can pass it to db
 	// populated by db (via mapstructure) or from provider (via json)
 	// Provider   string `json:"provider",mapstructure:"provider"`
-	Username   string `json:"username",mapstructure:"username"`
-	Name       string `json:"name",mapstructure:"name"`
-	Email      string `json:"email",mapstructure:"email"`
+	Username   string `json:"username" mapstructure:"username"`
+	Name       string `json:"name" mapstructure:"name"`
+	Email      string `json:"email" mapstructure:"email"`
 	CreatedOn  int64  `json:"createdon"`
 	LastUpdate int64  `json:"lastupdate"`
-	ID         int    `json:"id",mapstructure:"id"`
+	ID         int    `json:"id" mapstructure:"id"`
 	// jwt.StandardClaims
 }
 
@@ -95,12 +95,12 @@ func (u *IndieAuthUser) PrepareUserData() {
 
 // Team has members and provides acess to sites
 type Team struct {
-	Name       string   `json:"name",mapstructure:"name"`
-	Members    []string `json:"members",mapstructure:"members"` // just the emails
-	Sites      []string `json:"sites",mapstructure:"sites"`     // just the domains
-	CreatedOn  int64    `json:"createdon",mapstructure:"createdon"`
-	LastUpdate int64    `json:"lastupdate",mapstructure:"lastupdate"`
-	ID         int      `json:"id",mapstructure:"id"`
+	Name       string   `json:"name" mapstructure:"name"`
+	Members    []string `json:"members" mapstructure:"members"` // just the emails
+	Sites      []string `json:"sites" mapstructure:"sites"`     // just the domains
+	CreatedOn  int64    `json:"createdon" mapstructure:"createdon"`
+	LastUpdate int64    `json:"lastupdate" mapstructure:"lastupdate"`
+	ID         int      `json:"id" mapstructure:"id"`
 }
 
 // Site is the basic unit of auth
@@ -108,5 +108,5 @@ type Site struct {
 	Domain     string `json:"domain"`
 	CreatedOn  int64  `json:"createdon"`
 	LastUpdate int64  `json:"lastupdate"`
-	ID         int    `json:"id",mapstructure:"id"`
+	ID         int    `json:"id" mapstructure:"id"`
 }

--- a/pkg/transciever/client.go
+++ b/pkg/transciever/client.go
@@ -226,6 +226,7 @@ func serveWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	client.readPump()
 }
 
+// An echo function
 func Echo(conn *websocket.Conn) error {
 	messageType, r, err := conn.NextReader()
 	if err != nil {


### PR DESCRIPTION
I believe this fixes #74, by adding the support to pass tokens to downstream apps.  
Fixes #43 
I also believe this is a more complete implementation of #71, which was focused on ADFS.  This works for all providers.