### PR TITLE
Update readme with openresty examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ server {
 
       # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
       auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+      
+      # optionally add X-Vouch-IdP-Claims-* custom claims you are tracking
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
 
       # these return values are used by the @error401 call
       auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
@@ -81,11 +85,16 @@ server {
     location / {
       # forward authorized requests to your service protectedapp.yourdomain.com
       proxy_pass http://127.0.0.1:8080;
-      # you may need to set
+      # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
       #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      # in this bock as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+
       # set user header (usually an email)
       proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
+      # Pass any other custom claims you are tracking
+      # proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+      # proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,15 @@ If Vouch is running on the same host as the Nginx reverse proxy the response tim
   * be sure to direct the callback URL to the `/auth` endpoint
 * configure Nginx...
 
+The following nginx config assumes..
+
+* nginx, vouch.yourdomain.com and dev.yourdomain.com are running on the same server
+* you are running both domains behind https and have valid certs for both (if not, change to `listen 80`)
+
 ```{.nginxconf}
 server {
     listen 443 ssl http2;
-    server_name dev.yourdomain.com;
+    server_name protectedapp.yourdomain.com;
     root /var/www/html/;
 
     ssl_certificate /etc/letsencrypt/live/dev.yourdomain.com/fullchain.pem;
@@ -39,10 +44,8 @@ server {
     auth_request /validate;
 
     location = /validate {
-      # Vouch Proxy can run behind the same Nginx reverse proxy
-      # may need to comply to "upstream" server naming
-      proxy_pass http://vouch.yourdomain.com:9090/validate;
-
+      # forward the /validate request to Vouch Proxy
+      proxy_pass http://127.0.0.1:9090/validate;
       # be sure to pass the original host header
       proxy_set_header Host $http_host;
 
@@ -57,6 +60,11 @@ server {
       auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
       auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
       auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+
+      # Vouch Proxy can run behind the same Nginx reverse proxy
+      # may need to comply to "upstream" server naming
+      # proxy_pass http://vouch.yourdomain.com/validate;
+      # proxy_set_header Host $http_host;
     }
 
     # if validate returns `401 not authorized` then forward the request to the error401block
@@ -64,15 +72,18 @@ server {
 
     location @error401 {
         # redirect to Vouch Proxy for login
-        return 302 https://vouch.yourdomain.com:9090/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+        return 302 https://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+        # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https  
+        # but to get started you can just forward the end user to the port that vouch is running on
+        # return 302 http://vouch.yourdomain.com:9090/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
     }
 
-    # proxy pass authorized requests to your service
     location / {
-      proxy_pass http://dev.yourdomain.com:8080;
-      #  may need to set
+      # forward authorized requests to your service protectedapp.yourdomain.com
+      proxy_pass http://127.0.0.1:8080;
+      # you may need to set
       #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      #  in this bock as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+      # in this bock as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
       # set user header (usually an email)
       proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
     }
@@ -84,15 +95,17 @@ If Vouch is configured behind the **same** Nginx reverse proxy (perhaps so you c
 
 ```{.nginxconf}
 server {
-    listen 80 default_server;
+    listen 443 ssl http2;
     server_name vouch.yourdomain.com;
+    ssl_certificate /etc/letsencrypt/live/vouch.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/vouch.yourdomain.com/privkey.pem;
+
     location / {
-       proxy_pass http://127.0.0.1:9090;
-       # be sure to pass the original host header
-       proxy_set_header Host vouch.yourdomain.com;
+      proxy_pass http://127.0.0.1:9090;
+      # be sure to pass the original host header
+      proxy_set_header Host $http_host;
     }
 }
-
 ```
 
 An example of using Vouch Proxy with Nginx cacheing of the proxied validation request is available in [issue #76](https://github.com/vouch/vouch-proxy/issues/76#issuecomment-464028743).

--- a/README.md
+++ b/README.md
@@ -194,6 +194,90 @@ Thanks for the love, please open an issue describing your feature or idea before
 
 Please know that Vouch Proxy is not sponsored and is developed and supported on a volunteer basis.
 
+## Advanced Authorization Using OpenResty
+
+OpenResty® is a full-fledged web platform that integrates the standard Nginx core, LuaJIT, many carefully written Lua libraries, lots of high quality 3rd-party Nginx modules, and most of their external dependencies.
+
+You can replace nginx with [OpenResty](https://openresty.org/en/installation.html) fairly easily.
+
+With OpenResty and Lua it is possible to provide customized and advanced authorization on any header or claims vouch passes down.
+
+Add the following to nginx.conf `http{}` block...
+
+```{.nginxconf}
+  init_by_lua_block {
+    -- Function to find a key in a table
+    function tableHasKey(table,key)
+      return table[key] ~= nil
+    end
+    -- Function to turn a table with only values into a k=>v table
+    function Set (list)
+      local set = {}
+      for _, l in ipairs(list) do set[l] = true end
+        return set
+      end
+  }
+```
+
+Add the following into the `server{}` block of your service and modify the `authorized_users` and `authorized_groups` tables...
+
+```{.nginxconf}
+  server {
+
+    ....
+
+    access_by_lua_block {
+      -- Authorize a user via X-Vouch-User
+      -- Validate a user in nginx, instead of vouch
+      local authorized_users = Set {
+          "my@account.com",
+          "friend@gmail.com"
+          }
+      -- Verify the variable exists
+      if ngx.var.auth_resp_x_vouch_user then
+        -- Check if the found user is in the authorized_users table
+        if not tableHasKey(authorized_users, ngx.var.auth_resp_x_vouch_user) then
+            -- If not, throw a forbidden
+            ngx.exit(ngx.HTTP_FORBIDDEN)
+        end
+        else
+            -- Throw forbidden if variable doesn't exist
+            ngx.exit(ngx.HTTP_FORBIDDEN)
+      end
+
+      -- Authorize a user via X-Vouch-IdP-Groups
+      -- Validate that a user is in a group
+      local authorized_groups = Set {
+          "Domain Users",
+          "Website Users"
+          }
+      -- Verify the variable exists
+      if ngx.var.auth_resp_x_vouch_idp_claims_groups then
+        -- Check if the found user is in the allowed_users table
+        local cjson = require("cjson")
+        local groups = cjson.decode(ngx.var.auth_resp_x_vouch_idp_claims_groups)
+        local found = false
+        -- Parse the groups and check if they match any of our authorized groups
+        for i, group in ipairs(groups) do
+            if tableHasKey(authorized_groups, group) then
+              -- If we found an authorized group, say so and break the loop
+              found = true
+              break
+            end
+          end
+        -- If we didn't find out group in our list, then return forbidden
+        if not found then
+            -- If not, throw a forbidden
+            ngx.exit(ngx.HTTP_FORBIDDEN)
+        end
+        else
+            -- Throw forbidden if variable doesn't exist
+            ngx.exit(ngx.HTTP_FORBIDDEN)
+      end
+    }
+  }
+```
+
 ## Project renamed to **Vouch Proxy** in January 2019
 
 In January the project was renamed to [vouch/vouch-proxy](https://github.com/vouch/vouch-proxy) from `LassoProject/lasso`.  This is to [avoid a naming conflict](https://github.com/vouch/vouch-proxy/issues/35) with another project.
@@ -219,7 +303,7 @@ Sorry for the inconvenience but we wanted to make this change at this relatively
 
 This notice will remain in the README through June 2019
 
-## the flow of login and authentication using Google Oauth
+## The flow of login and authentication using Google Oauth
 
 * Bob visits `https://private.oursites.com`
 * the Nginx reverse proxy...

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ server {
 
       # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
       auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
-      
+
       # optionally add X-Vouch-IdP-Claims-* custom claims you are tracking
       #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
       #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+      # optinally add X-Vouch-IdP-AccessToken or X-Vouch-IdP-IdToken
+      #    auth_request_set $auth_resp_x_vouch_idp_accesstoken $upstream_http_x_vouch_idp_accesstoken;
+      #    auth_request_set $auth_resp_x_vouch_idp_idtoken $upstream_http_x_vouch_idp_idtoken;
 
       # these return values are used by the @error401 call
       auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
@@ -92,9 +95,12 @@ server {
 
       # set user header (usually an email)
       proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
-      # Pass any other custom claims you are tracking
-      # proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
-      # proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+      # optionally pass any custom claims you are tracking
+      #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+      #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+      # optionally pass the accesstoken or idtoken
+      #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
+      #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
     }
 }
 

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -77,6 +77,19 @@ vouch:
     jwt: X-Vouch-Token
     querystring: access_token
     redirect: X-Vouch-Requested-URI
+    # Claims is a list of claims that will be stored in the JWT and passed down to applications via headers
+    # By default claims are sent down as headers with a prefix of X-Vouch-IdP-Claims-ClaimKey
+    # Only when a claim is found in the user's info will the header exist.  This is optional.  These are case sensitive.
+    claims:
+      - groups
+      - given_name
+    # these will result in two headers being passed back to nginx
+    # X-Vouch-IdP-Claims-groups
+    # X-Vouch-IdP-Claims-given_name
+      
+    # Customizable claim header. 
+    # claimheader: My-Custom-Claim-Prefix
+
 
   db: 
     file: data/vouch_bolt.db

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -60,6 +60,8 @@ vouch:
     # domain: yourdomain.com
     secure: true
     httpOnly: true
+    # Set cookie maxAge to 0 to delete the cookie every time the browser is closed.
+    maxAge: 14400
 
   session:
     # name of session variable stored locally

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -8,10 +8,15 @@
 vouch:
   # logLevel: debug
   logLevel: info
+
+  # testing - force all 302 redirects to be rendered as a webpage with a link
+  # if you're having problems, turn on testing
+  testing: true
+
   listen: 0.0.0.0
   port: 9090
 
-  # domains:
+  # domains -
   # each of these domains must serve the url https://vouch.$domains[0] https://vouch.$domains[1] ...
   # so that the cookie which stores the JWT can be set in the relevant domain
   # you usually *don't* want to list every individual website that will be protected
@@ -31,7 +36,7 @@ vouch:
   # You will need to direct people to the Vouch Proxy login page from your application.
   # publicAccess: false
 
-  # whiteList (optional) allows only the listed usernames
+  # whiteList - (optional) allows only the listed usernames
   # usernames are usually email addresses (google, most oidc providers) or login/username for github and github enterprise
   whiteList:
   - bob@yourdomain.com
@@ -39,7 +44,7 @@ vouch:
   - joe@yourdomain.com
 
   jwt:
-    # secret: a random string used to cryptographically sign the jwt
+    # secret - a random string used to cryptographically sign the jwt
     # Vouch Proxy complains if the string is less than 44 characters (256 bits as 32 base64 bytes)
     # if the secret is not set here then..
     # look for the secret in `./config/secret`
@@ -66,7 +71,7 @@ vouch:
   session:
     # name of session variable stored locally
     name: VouchSession
-    # key: a cryptographic string used to store the session variable
+    # key - a cryptographic string used to store the session variable
     # if the key is not set here then it is generated at startup and stored in memory
     # Vouch Proxy complains if the string is less than 44 characters (256 bits as 32 base64 bytes)
     # you only want to set this if you're running multiple user facing vouch.yourdomain.com instances
@@ -77,7 +82,17 @@ vouch:
     jwt: X-Vouch-Token
     querystring: access_token
     redirect: X-Vouch-Requested-URI
-    # Claims is a list of claims that will be stored in the JWT and passed down to applications via headers
+
+    # GENERAL WARNING ABOUT claims AND tokens
+    # all of these config elements can cause performance impacts due to the amount of information being 
+    # moved around.  They will get added to the Vouch cookie and (possibly) make it large.  The Vouch cookie will 
+    # get split up into several cookies. Every request will process the cookies in order to extract and create the 
+    # additional headers which get returned.  But if you need it, you need it.
+    # With large cookies and headers it will require additional nginx config to open up the buffers a bit..
+    # see `large_client_header_buffers` http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers
+    # and `proxy_buffer_size` http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffer_size
+
+    # claims - a list of claims that will be stored in the JWT and passed down to applications via headers
     # By default claims are sent down as headers with a prefix of X-Vouch-IdP-Claims-ClaimKey
     # Only when a claim is found in the user's info will the header exist.  This is optional.  These are case sensitive.
     claims:
@@ -87,19 +102,23 @@ vouch:
     # X-Vouch-IdP-Claims-groups
     # X-Vouch-IdP-Claims-given_name
       
-    # Customizable claim header. 
+    # claimheader - Customizable claim header prefix (instead of default `X-Vouch-IdP-Claims-`) 
     # claimheader: My-Custom-Claim-Prefix
 
+    # accesstoken - Pass the user's access token from the provider.  This is useful if you need to pass the IdP token to a downstream
+    # application. This is optional.
+    # accesstoken: X-Vouch-IdP-AccessToken
+    # idtoken - Pass the user's Id token from the provider.  This is useful if you need to pass this token to a downstream
+    # application. This is optional.
+    # idtoken: X-Vouch-IdP-IdToken
 
   db: 
     file: data/vouch_bolt.db
 
-  # testing: force all 302 redirects to be rendered as a webpage with a link
-  testing: true
-  # test_url: add this URL to the page which vouch displays
+  # test_url - add this URL to the page which vouch displays
   test_url: http://yourdomain.com
-  # webapp: WIP for web interface to vouch (mostly logs)
-  webapp: true
+  # webapp - WIP for web interface to vouch (mostly logs)
+  # webapp: true
 
 #
 # OAuth Provider

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -666,8 +666,9 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *stru
 	formData.Set("resource", cfg.GenOAuth.RedirectURL)
 	formData.Set("client_id", cfg.GenOAuth.ClientID)
 	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
-	formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
-
+	if cfg.GenOAuth.ClientSecret != "" {
+		formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
+	}
 	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
 	if err != nil {
 		return err

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -196,20 +196,25 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if len(cfg.Cfg.Headers.Claims) > 0 {
+		log.Debug("Found claims in config, finding specific keys...")
 		// Run through all the claims found
 		for k, v := range claims.CustomClaims {
 			// Run through the claims we are looking for
 			for _, cv := range cfg.Cfg.Headers.Claims {
 				// Check for matching claim
 				if cv == k {
+					log.Debug("Found matching claim key: ", k)
+					customHeader := strings.Join([]string{cfg.Cfg.Headers.ClaimHeader, k}, "")
 					if val, ok := v.(string); ok {
-						w.Header().Add(cfg.Cfg.Headers.ClaimHeader, val)
+						w.Header().Add(customHeader, val)
+						log.Debug("Adding header for claim: ", k, " Name: ", customHeader, " Value: ", val)
 					} else if val, ok := v.([]interface{}); ok {
 						strs := make([]string, len(val))
 						for i, v := range val {
 							strs[i] = fmt.Sprintf("\"%s\"", v)
 						}
-						w.Header().Add(cfg.Cfg.Headers.ClaimHeader, strings.Join(strs, ","))
+						log.Debug("Adding header for claim: ", k, " Name: ", customHeader, " Value: ", strings.Join(strs, ","))
+						w.Header().Add(customHeader, strings.Join(strs, ","))
 					} else {
 						log.Error("Couldn't parse header type.  Please submit an issue.")
 					}
@@ -220,8 +225,7 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add(cfg.Cfg.Headers.User, claims.Username)
 	w.Header().Add(cfg.Cfg.Headers.Success, "true")
-	fastlog.Debug("response header",
-		zap.String(cfg.Cfg.Headers.User, w.Header().Get(cfg.Cfg.Headers.User)))
+	log.Debugf("response header %+v", w.Header())
 
 	// good to go!!
 	if cfg.Cfg.Testing {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -226,7 +227,23 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add(cfg.Cfg.Headers.User, claims.Username)
 	w.Header().Add(cfg.Cfg.Headers.Success, "true")
-	log.Debugf("response header %+v", w.Header())
+
+	if cfg.Cfg.Headers.AccessToken != "" {
+		if claims.PAccessToken != "" {
+			w.Header().Add(cfg.Cfg.Headers.AccessToken, claims.PAccessToken)
+		}
+	}
+	if cfg.Cfg.Headers.IDToken != "" {
+		if claims.PIdToken != "" {
+			w.Header().Add(cfg.Cfg.Headers.IDToken, claims.PIdToken)
+
+		}
+	}
+	// fastlog.Debugf("response headers %+v", w.Header())
+	// fastlog.Debug("response header",
+	// 	zap.String(cfg.Cfg.Headers.User, w.Header().Get(cfg.Cfg.Headers.User)))
+	fastlog.Debug("response header",
+		zap.Any("all headers", w.Header()))
 
 	// good to go!!
 	if cfg.Cfg.Testing {
@@ -422,7 +439,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	session, err := sessstore.Get(r, cfg.Cfg.Session.Name)
 	if err != nil {
-		log.Errorf("could not find session store %s", cfg.Cfg.Session.Name)
+		log.Errorf("/auth could not find session store %s", cfg.Cfg.Session.Name)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -430,7 +447,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	// is the nonce "state" valid?
 	queryState := r.URL.Query().Get("state")
 	if session.Values["state"] != queryState {
-		log.Errorf("Invalid session state: stored %s, returned %s", session.Values["state"], queryState)
+		log.Errorf("/auth Invalid session state: stored %s, returned %s", session.Values["state"], queryState)
 		renderIndex(w, "/auth Invalid session state.")
 		return
 	}
@@ -438,7 +455,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	errorState := r.URL.Query().Get("error")
 	if errorState != "" {
 		errorDescription := r.URL.Query().Get("error_description")
-		log.Warn("Error state: ", errorState, ", Error description: ", errorDescription)
+		log.Warn("/auth Error state: ", errorState, ", Error description: ", errorDescription)
 		w.WriteHeader(http.StatusForbidden)
 		renderIndex(w, "FORBIDDEN: "+errorDescription)
 		return
@@ -446,15 +463,17 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 	user := structs.User{}
 	customClaims := structs.CustomClaims{}
+	ptokens := structs.PTokens{}
 
-	if err := getUserInfo(r, &user, &customClaims); err != nil {
+	if err := getUserInfo(r, &user, &customClaims, &ptokens); err != nil {
 		log.Error(err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	log.Debugf("Claims from userinfo: %+v", customClaims)
-	log.Debug("CallbackHandler")
-	log.Debug(user)
+	log.Debugf("/auth Claims from userinfo: %+v", customClaims)
+	//getProviderJWT(r, &user)
+	log.Debug("/auth CallbackHandler")
+	log.Debugf("/auth %+v", user)
 
 	if ok, err := VerifyUser(user); !ok {
 		log.Error(err)
@@ -470,7 +489,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// issue the jwt
-	tokenstring := jwtmanager.CreateUserTokenString(user, customClaims)
+	tokenstring := jwtmanager.CreateUserTokenString(user, customClaims, ptokens)
 	cookie.SetCookie(w, r, tokenstring)
 
 	// get the originally requested URL so we can send them on their way
@@ -492,7 +511,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 
 // TODO: put all getUserInfo logic into its own pkg
 
-func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) error {
+func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) error {
 
 	// indieauth sends the "me" setting in json back to the callback, so just pluck it from the callback
 	if cfg.GenOAuth.Provider == cfg.Providers.IndieAuth {
@@ -500,14 +519,16 @@ func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.Cust
 	} else if cfg.GenOAuth.Provider == cfg.Providers.ADFS {
 		return getUserInfoFromADFS(r, user, customClaims)
 	}
-
-	providerToken, err := cfg.OAuthClient.Exchange(oauth2.NoContext, r.URL.Query().Get("code"))
+	providerToken, err := cfg.OAuthClient.Exchange(context.TODO(), r.URL.Query().Get("code"))
 	if err != nil {
 		return err
 	}
+	ptokens.PAccessToken = providerToken.AccessToken
+	ptokens.PIdToken = providerToken.Extra("id_token").(string)
+	log.Debugf("ptokens: %+v", ptokens)
 
 	// make the "third leg" request back to google to exchange the token for the userinfo
-	client := cfg.OAuthClient.Client(oauth2.NoContext, providerToken)
+	client := cfg.OAuthClient.Client(context.TODO(), providerToken)
 	if cfg.GenOAuth.Provider == cfg.Providers.Google {
 		return getUserInfoFromGoogle(client, user, customClaims)
 	} else if cfg.GenOAuth.Provider == cfg.Providers.GitHub {
@@ -693,7 +714,7 @@ type adfsTokenRes struct {
 // More info: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers#supported-scenarios
 func getUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
 	code := r.URL.Query().Get("code")
-	log.Errorf("code: %s", code)
+	log.Debugf("code: %s", code)
 
 	formData := url.Values{}
 	formData.Set("code", code)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -423,7 +423,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	model.PutUser(user)
 
 	// issue the jwt
-	tokenstring := jwtmanager.CreateUserTokenString(user)
+	tokenstring := jwtmanager.CreateUserTokenString(user, customClaims)
 	cookie.SetCookie(w, r, tokenstring)
 
 	// get the originally requested URL so we can send them on their way

--- a/main.go
+++ b/main.go
@@ -55,23 +55,23 @@ func main() {
 		"listen", listen,
 		"oauth.provider", cfg.GenOAuth.Provider)
 
-	mux := mux.NewRouter()
+	theMux := mux.NewRouter()
 
 	authH := http.HandlerFunc(handlers.ValidateRequestHandler)
-	mux.HandleFunc("/validate", timelog.TimeLog(authH))
-	mux.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
+	theMux.HandleFunc("/validate", timelog.TimeLog(authH))
+	theMux.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
 
 	loginH := http.HandlerFunc(handlers.LoginHandler)
-	mux.HandleFunc("/login", timelog.TimeLog(loginH))
+	theMux.HandleFunc("/login", timelog.TimeLog(loginH))
 
 	logoutH := http.HandlerFunc(handlers.LogoutHandler)
-	mux.HandleFunc("/logout", timelog.TimeLog(logoutH))
+	theMux.HandleFunc("/logout", timelog.TimeLog(logoutH))
 
 	callH := http.HandlerFunc(handlers.CallbackHandler)
-	mux.HandleFunc("/auth", timelog.TimeLog(callH))
+	theMux.HandleFunc("/auth", timelog.TimeLog(callH))
 
 	healthH := http.HandlerFunc(handlers.HealthcheckHandler)
-	mux.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
+	theMux.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
 
 	if logger.Desugar().Core().Enabled(zap.DebugLevel) {
 		path, err := filepath.Abs(staticDir)
@@ -81,20 +81,20 @@ func main() {
 		logger.Debugf("serving static files from %s", path)
 	}
 	// https://golangcode.com/serve-static-assets-using-the-mux-router/
-	mux.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, (http.FileServer(http.Dir("." + staticDir)))))
+	theMux.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
 
 	if cfg.Cfg.WebApp {
 		logger.Info("enabling websocket")
 		tran.ExplicitInit()
-		mux.Handle("/ws", tran.WS)
+		theMux.Handle("/ws", tran.WS)
 	}
 
 	// socketio := tran.NewServer()
-	// mux.Handle("/socket.io/", cors.AllowAll(socketio))
+	// theMux.Handle("/socket.io/", cors.AllowAll(socketio))
 	// http.Handle("/socket.io/", tran.Server)
 
 	srv := &http.Server{
-		Handler: mux,
+		Handler: theMux,
 		Addr:    listen,
 		// Good practice: enforce timeouts for servers you create!
 		WriteTimeout: 15 * time.Second,

--- a/main.go
+++ b/main.go
@@ -55,23 +55,23 @@ func main() {
 		"listen", listen,
 		"oauth.provider", cfg.GenOAuth.Provider)
 
-	theMux := mux.NewRouter()
+	muxR := mux.NewRouter()
 
 	authH := http.HandlerFunc(handlers.ValidateRequestHandler)
-	theMux.HandleFunc("/validate", timelog.TimeLog(authH))
-	theMux.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
+	muxR.HandleFunc("/validate", timelog.TimeLog(authH))
+	muxR.HandleFunc("/_external-auth-{id}", timelog.TimeLog(authH))
 
 	loginH := http.HandlerFunc(handlers.LoginHandler)
-	theMux.HandleFunc("/login", timelog.TimeLog(loginH))
+	muxR.HandleFunc("/login", timelog.TimeLog(loginH))
 
 	logoutH := http.HandlerFunc(handlers.LogoutHandler)
-	theMux.HandleFunc("/logout", timelog.TimeLog(logoutH))
+	muxR.HandleFunc("/logout", timelog.TimeLog(logoutH))
 
 	callH := http.HandlerFunc(handlers.CallbackHandler)
-	theMux.HandleFunc("/auth", timelog.TimeLog(callH))
+	muxR.HandleFunc("/auth", timelog.TimeLog(callH))
 
 	healthH := http.HandlerFunc(handlers.HealthcheckHandler)
-	theMux.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
+	muxR.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
 
 	if logger.Desugar().Core().Enabled(zap.DebugLevel) {
 		path, err := filepath.Abs(staticDir)
@@ -81,20 +81,20 @@ func main() {
 		logger.Debugf("serving static files from %s", path)
 	}
 	// https://golangcode.com/serve-static-assets-using-the-mux-router/
-	theMux.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
+	muxR.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
 
 	if cfg.Cfg.WebApp {
 		logger.Info("enabling websocket")
 		tran.ExplicitInit()
-		theMux.Handle("/ws", tran.WS)
+		muxR.Handle("/ws", tran.WS)
 	}
 
 	// socketio := tran.NewServer()
-	// theMux.Handle("/socket.io/", cors.AllowAll(socketio))
+	// muxR.Handle("/socket.io/", cors.AllowAll(socketio))
 	// http.Handle("/socket.io/", tran.Server)
 
 	srv := &http.Server{
-		Handler: theMux,
+		Handler: muxR,
 		Addr:    listen,
 		// Good practice: enforce timeouts for servers you create!
 		WriteTimeout: 15 * time.Second,

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -51,7 +51,7 @@ type config struct {
 		QueryString string   `mapstructure:"querystring"`
 		Redirect    string   `mapstructure:"redirect"`
 		Success     string   `mapstructure:"success"`
-		claimHeader string   `mapstructure:"claimheader"`
+		ClaimHeader string   `mapstructure:"claimheader"`
 		Claims      []string `mapstructure:"claims"`
 	}
 	DB struct {
@@ -459,6 +459,9 @@ func SetDefaults() {
 	}
 	if !viper.IsSet(Branding.LCName + ".headers.success") {
 		Cfg.Headers.Success = "X-" + Branding.CcName + "-Success"
+	}
+	if !viper.IsSet(Branding.LCName + ".headers.claimheader") {
+		Cfg.Headers.ClaimHeader = "X-" + Branding.CcName + "-IdP-Claims-"
 	}
 
 	// db defaults

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -44,14 +44,14 @@ type config struct {
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 		MaxAge   int    `mapstructure:"maxage"`
 	}
-	Claims  []string `mapstructure:"claims"`
+
 	Headers struct {
-		JWT         string `mapstructure:"jwt"`
-		User        string `mapstructure:"user"`
-		QueryString string `mapstructure:"querystring"`
-		Redirect    string `mapstructure:"redirect"`
-		Success     string `mapstructure:"success"`
-		Claims      string `mapstructure:"claims"`
+		JWT         string   `mapstructure:"jwt"`
+		User        string   `mapstructure:"user"`
+		QueryString string   `mapstructure:"querystring"`
+		Redirect    string   `mapstructure:"redirect"`
+		Success     string   `mapstructure:"success"`
+		Claims      []string `mapstructure:"claims"`
 	}
 	DB struct {
 		File string `mapstructure:"file"`

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -51,6 +51,7 @@ type config struct {
 		QueryString string   `mapstructure:"querystring"`
 		Redirect    string   `mapstructure:"redirect"`
 		Success     string   `mapstructure:"success"`
+		claimHeader string   `mapstructure:"claimheader"`
 		Claims      []string `mapstructure:"claims"`
 	}
 	DB struct {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -224,7 +224,9 @@ func setDevelopmentLogger() {
 
 // InitForTestPurposes is called by most *_testing.go files in Vouch Proxy
 func InitForTestPurposes() {
-	os.Setenv(Branding.UCName+"_CONFIG", "../../config/test_config.yml")
+	if err := os.Setenv(Branding.UCName+"_CONFIG", "../../config/test_config.yml"); err != nil {
+		log.Error(err)
+	}
 	// log.Debug("opening config")
 	setDevelopmentLogger()
 	ParseConfig()
@@ -255,17 +257,16 @@ func ParseConfig() {
 		log.Fatalf("Fatal error config file: %s", err.Error())
 		panic(err)
 	}
-	err = UnmarshalKey(Branding.LCName, &Cfg)
-	if err != nil {
-		log.Errorf("Couldn't unmarshal configuration")
+	if err = UnmarshalKey(Branding.LCName, &Cfg); err != nil {
+		log.Error(err)
 	}
 	if len(Cfg.Domains) == 0 {
 		// then lets check for "lasso"
 		var oldConfig config
-		err = UnmarshalKey(Branding.OldLCName, &oldConfig)
-		if err != nil {
-			log.Errorf("Couldn't unmarshal configuration")
+		if err = UnmarshalKey(Branding.OldLCName, &oldConfig); err != nil {
+			log.Error(err)
 		}
+
 		if len(oldConfig.Domains) != 0 {
 			log.Errorf(`						
 
@@ -601,6 +602,8 @@ func isTCPPortAvailable(listen string) bool {
 		log.Error(err)
 		return false
 	}
-	conn.Close()
+	if err = conn.Close(); err != nil {
+		log.Error(err)
+	}
 	return true
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -42,6 +42,7 @@ type config struct {
 		Domain   string `mapstructure:"domain"`
 		Secure   bool   `mapstructure:"secure"`
 		HTTPOnly bool   `mapstructure:"httpOnly"`
+		MaxAge   int    `mapstructure:"maxage"`
 	}
 	Headers struct {
 		JWT         string `mapstructure:"jwt"`
@@ -340,6 +341,15 @@ func BasicTest() error {
 			Branding.LCName+".session.key",
 			minBase64Length)
 	}
+	if Cfg.Cookie.MaxAge < 0 {
+		return errors.New("configuration error: cookie maxAge cannot be lower than 0")
+	}
+	if Cfg.JWT.MaxAge <= 0 {
+		return errors.New("configuration error: JWT maxAge cannot be zero or lower")
+	}
+	if Cfg.Cookie.MaxAge > Cfg.JWT.MaxAge {
+		return errors.New("configuration error: Cookie maxAge cannot be larger than the JWT maxAge")
+	}
 	return nil
 }
 
@@ -414,6 +424,9 @@ func SetDefaults() {
 	}
 	if !viper.IsSet(Branding.LCName + ".cookie.httpOnly") {
 		Cfg.Cookie.HTTPOnly = true
+	}
+	if !viper.IsSet(Branding.LCName + ".cookie.maxAge") {
+		Cfg.Cookie.MaxAge = Cfg.JWT.MaxAge * 60
 	}
 
 	// headers defaults

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -53,6 +53,8 @@ type config struct {
 		Success     string   `mapstructure:"success"`
 		ClaimHeader string   `mapstructure:"claimheader"`
 		Claims      []string `mapstructure:"claims"`
+		AccessToken string   `mapstructure:"accesstoken"`
+		IDToken     string   `mapstructure:"idtoken"`
 	}
 	DB struct {
 		File string `mapstructure:"file"`

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -342,13 +342,13 @@ func BasicTest() error {
 			minBase64Length)
 	}
 	if Cfg.Cookie.MaxAge < 0 {
-		return errors.New("configuration error: cookie maxAge cannot be lower than 0")
+		return fmt.Errorf("configuration error: cookie maxAge cannot be lower than 0 (currently: %d)", Cfg.Cookie.MaxAge)
 	}
 	if Cfg.JWT.MaxAge <= 0 {
-		return errors.New("configuration error: JWT maxAge cannot be zero or lower")
+		return fmt.Errorf("configuration error: JWT maxAge cannot be zero or lower (currently: %d)", Cfg.JWT.MaxAge)
 	}
 	if Cfg.Cookie.MaxAge > Cfg.JWT.MaxAge {
-		return errors.New("configuration error: Cookie maxAge cannot be larger than the JWT maxAge")
+		return fmt.Errorf("configuration error: Cookie maxAge (%d) cannot be larger than the JWT maxAge (%d)", Cfg.Cookie.MaxAge, Cfg.JWT.MaxAge)
 	}
 	return nil
 }
@@ -426,7 +426,13 @@ func SetDefaults() {
 		Cfg.Cookie.HTTPOnly = true
 	}
 	if !viper.IsSet(Branding.LCName + ".cookie.maxAge") {
-		Cfg.Cookie.MaxAge = Cfg.JWT.MaxAge * 60
+		Cfg.Cookie.MaxAge = Cfg.JWT.MaxAge
+	} else {
+		// it is set!  is it bigger than jwt.maxage?
+		if Cfg.Cookie.MaxAge > Cfg.JWT.MaxAge {
+			log.Warnf("setting `%s.cookie.maxage` to `%s.jwt.maxage` value of %d minutes (curently set to %d minutes)", Branding.LCName, Branding.LCName, Cfg.JWT.MaxAge, Cfg.Cookie.MaxAge)
+			Cfg.Cookie.MaxAge = Cfg.JWT.MaxAge
+		}
 	}
 
 	// headers defaults
@@ -471,7 +477,7 @@ func SetDefaults() {
 	if viper.IsSet(Branding.LCName + ".test_url") {
 		Cfg.TestURLs = append(Cfg.TestURLs, Cfg.TestURL)
 	}
-	// TODO: proably change this name, maybe set the domain/port the webapp runs on
+	// TODO: probably change this name, maybe set the domain/port the webapp runs on
 	if !viper.IsSet(Branding.LCName + ".webapp") {
 		Cfg.WebApp = false
 	}

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -44,12 +44,14 @@ type config struct {
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 		MaxAge   int    `mapstructure:"maxage"`
 	}
+	Claims  []string `mapstructure:"claims"`
 	Headers struct {
 		JWT         string `mapstructure:"jwt"`
 		User        string `mapstructure:"user"`
 		QueryString string `mapstructure:"querystring"`
 		Redirect    string `mapstructure:"redirect"`
 		Success     string `mapstructure:"success"`
+		Claims      string `mapstructure:"claims"`
 	}
 	DB struct {
 		File string `mapstructure:"file"`
@@ -252,11 +254,17 @@ func ParseConfig() {
 		log.Fatalf("Fatal error config file: %s", err.Error())
 		panic(err)
 	}
-	UnmarshalKey(Branding.LCName, &Cfg)
+	err = UnmarshalKey(Branding.LCName, &Cfg)
+	if err != nil {
+		log.Errorf("Couldn't unmarshal configuration")
+	}
 	if len(Cfg.Domains) == 0 {
 		// then lets check for "lasso"
 		var oldConfig config
-		UnmarshalKey(Branding.OldLCName, &oldConfig)
+		err = UnmarshalKey(Branding.OldLCName, &oldConfig)
+		if err != nil {
+			log.Errorf("Couldn't unmarshal configuration")
+		}
 		if len(oldConfig.Domains) != 0 {
 			log.Errorf(`						
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -308,8 +308,9 @@ func BasicTest() error {
 	case GenOAuth.ClientID == "":
 		// everyone has a clientID
 		return errors.New("configuration error: oauth.client_id not found")
-	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.ClientSecret == "":
+	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.ADFS && GenOAuth.Provider != Providers.OIDC && GenOAuth.ClientSecret == "":
 		// everyone except IndieAuth has a clientSecret
+		// ADFS and OIDC providers also do not require this, but can have it optionally set.
 		return errors.New("configuration error: o`auth.client_secret not found")
 	case GenOAuth.Provider != Providers.Google && GenOAuth.AuthURL == "":
 		// everyone except IndieAuth and Google has an authURL

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -151,6 +151,7 @@ func ClearCookie(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// SplitCookie separate string into several strings of specified length
 func SplitCookie(longString string, maxLen int) []string {
 	splits := []string{}
 

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -13,7 +13,7 @@ var log = cfg.Cfg.Logger
 
 // SetCookie http
 func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
-	setCookie(w, r, val, cfg.Cfg.Cookie.MaxAge)
+	setCookie(w, r, val, cfg.Cfg.Cookie.MaxAge*60) // convert minutes to seconds
 }
 
 func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
@@ -27,15 +27,15 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
 	// Cookies get deleted after the current session (when the browser closes) when no expires or maxage setting is set,
 	// or when expires is set to 0.
-		http.SetCookie(w, &http.Cookie{
-			Name:     cfg.Cfg.Cookie.Name,
-			Value:    val,
-			Path:     "/",
-			Domain:   domain,
-			MaxAge:   maxAge,
-			Secure:   cfg.Cfg.Cookie.Secure,
-			HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
-		})
+	http.SetCookie(w, &http.Cookie{
+		Name:     cfg.Cfg.Cookie.Name,
+		Value:    val,
+		Path:     "/",
+		Domain:   domain,
+		MaxAge:   maxAge,
+		Secure:   cfg.Cfg.Cookie.Secure,
+		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+	})
 }
 
 // Cookie get the vouch jwt cookie

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -9,19 +9,15 @@ import (
 	"github.com/vouch/vouch-proxy/pkg/domains"
 )
 
-var defaultMaxAge = cfg.Cfg.JWT.MaxAge * 60
 var log = cfg.Cfg.Logger
 
 // SetCookie http
 func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
-	setCookie(w, r, val, defaultMaxAge)
+	setCookie(w, r, val, cfg.Cfg.Cookie.MaxAge)
 }
 
 func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 	// foreach domain
-	if maxAge == 0 {
-		maxAge = defaultMaxAge
-	}
 	domain := domains.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
 	if cfg.Cfg.Cookie.Domain != "" {
@@ -29,15 +25,17 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
 	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
-	http.SetCookie(w, &http.Cookie{
-		Name:     cfg.Cfg.Cookie.Name,
-		Value:    val,
-		Path:     "/",
-		Domain:   domain,
-		MaxAge:   maxAge,
-		Secure:   cfg.Cfg.Cookie.Secure,
-		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
-	})
+	// Cookies get deleted after the current session (when the browser closes) when no expires or maxage setting is set,
+	// or when expires is set to 0.
+		http.SetCookie(w, &http.Cookie{
+			Name:     cfg.Cfg.Cookie.Name,
+			Value:    val,
+			Path:     "/",
+			Domain:   domain,
+			MaxAge:   maxAge,
+			Secure:   cfg.Cfg.Cookie.Secure,
+			HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+		})
 }
 
 // Cookie get the vouch jwt cookie

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -2,12 +2,18 @@ package cookie
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
+	"unicode/utf8"
 
 	// "github.com/vouch/vouch-proxy/pkg/structs"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/domains"
 )
+
+const maxCookieSize = 4000
 
 var log = cfg.Cfg.Logger
 
@@ -17,6 +23,7 @@ func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
 }
 
 func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
+	cookieName := cfg.Cfg.Cookie.Name
 	// foreach domain
 	domain := domains.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
@@ -24,10 +31,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		domain = cfg.Cfg.Cookie.Domain
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
-	// log.Debugf("cookie %s expires %d", cfg.Cfg.Cookie.Name, expires)
-	// Cookies get deleted after the current session (when the browser closes) when no expires or maxage setting is set,
-	// or when expires is set to 0.
-	http.SetCookie(w, &http.Cookie{
+	cookie := http.Cookie{
 		Name:     cfg.Cfg.Cookie.Name,
 		Value:    val,
 		Path:     "/",
@@ -35,27 +39,128 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		MaxAge:   maxAge,
 		Secure:   cfg.Cfg.Cookie.Secure,
 		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
-	})
+	}
+	cookieSize := len(cookie.String())
+	cookie.Value = ""
+	emptyCookieSize := len(cookie.String())
+	// Cookies have a max size of 4096 bytes, but to support most browsers, we should stay below 4000 bytes
+	// https://tools.ietf.org/html/rfc6265#section-6.1
+	// http://browsercookielimits.squawky.net/
+	if cookieSize > maxCookieSize {
+		// https://www.lifewire.com/cookie-limit-per-domain-3466809
+		log.Warnf("cookie size: %d.  cookie sizes over ~4093 bytes(depending on the browser and platform) have shown to cause issues or simply aren't supported.", cookieSize)
+		cookieParts := SplitCookie(val, maxCookieSize-emptyCookieSize)
+		for i, cookiePart := range cookieParts {
+			// Cookies are named 1of3, 2of3, 3of3
+			cookieName = fmt.Sprintf("%s_%dof%d", cfg.Cfg.Cookie.Name, i+1, len(cookieParts))
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookieName,
+				Value:    cookiePart,
+				Path:     "/",
+				Domain:   domain,
+				MaxAge:   maxAge,
+				Secure:   cfg.Cfg.Cookie.Secure,
+				HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+			})
+		}
+	} else {
+		http.SetCookie(w, &http.Cookie{
+			Name:     cookieName,
+			Value:    val,
+			Path:     "/",
+			Domain:   domain,
+			MaxAge:   maxAge,
+			Secure:   cfg.Cfg.Cookie.Secure,
+			HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+		})
+	}
 }
 
 // Cookie get the vouch jwt cookie
 func Cookie(r *http.Request) (string, error) {
-	cookie, err := r.Cookie(cfg.Cfg.Cookie.Name)
-	if err != nil {
-		return "", err
+
+	var cookieParts []string
+	var numParts = -1
+
+	var err error
+	cookies := r.Cookies()
+	// Get the remaining parts
+	// search for cookie parts in order
+	// this is the hotpath so we're trying to only walk once
+	for _, cookie := range cookies {
+		if cookie.Name == cfg.Cfg.Cookie.Name {
+			return cookie.Value, nil
+		}
+		if strings.HasPrefix(cookie.Name, fmt.Sprintf("%s_", cfg.Cfg.Cookie.Name)) {
+			log.Debugw("cookie",
+				"cookieName", cookie.Name,
+				"cookieValue", cookie.Value,
+			)
+			xOFy := strings.Split(cookie.Name, "_")[1]
+			xyArray := strings.Split(xOFy, "of")
+			if numParts == -1 { // then its uninitialized
+				if numParts, err = strconv.Atoi(xyArray[1]); err != nil {
+					return "", fmt.Errorf("multipart cookie fail: %s", err)
+				}
+				log.Debugf("make cookieParts of size %d", numParts)
+				cookieParts = make([]string, numParts)
+			}
+			var i int
+			if i, err = strconv.Atoi(xyArray[0]); err != nil {
+				return "", fmt.Errorf("multipart cookie fail: %s", err)
+			}
+			cookieParts[i-1] = cookie.Value
+		}
+
 	}
-	if cookie.Value == "" {
+	// combinedCookieStr := combinedCookie.String()
+	combinedCookieStr := strings.Join(cookieParts, "")
+	if combinedCookieStr == "" {
 		return "", errors.New("Cookie token empty")
 	}
 
-	log.Debugw("cookie",
-		"cookieName", cfg.Cfg.Cookie.Name,
-		"cookieValue", cookie.Value,
+	log.Debugw("combined cookie",
+		"cookieValue", combinedCookieStr,
 	)
-	return cookie.Value, err
+	return combinedCookieStr, err
 }
 
 // ClearCookie get rid of the existing cookie
 func ClearCookie(w http.ResponseWriter, r *http.Request) {
-	setCookie(w, r, "delete", -1)
+	cookies := r.Cookies()
+	domain := domains.Matches(r.Host)
+	// Allow overriding the cookie domain in the config file
+	if cfg.Cfg.Cookie.Domain != "" {
+		domain = cfg.Cfg.Cookie.Domain
+		log.Debugf("setting the cookie domain to %v", domain)
+	}
+	// search for cookie parts
+	for _, cookie := range cookies {
+		if strings.HasPrefix(cookie.Name, cfg.Cfg.Cookie.Name) {
+			log.Debugf("deleting cookie: %s", cookie.Name)
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookie.Name,
+				Value:    "delete",
+				Path:     "/",
+				Domain:   domain,
+				MaxAge:   -1,
+				Secure:   cfg.Cfg.Cookie.Secure,
+				HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+			})
+		}
+	}
+}
+
+func SplitCookie(longString string, maxLen int) []string {
+	splits := []string{}
+
+	var l, r int
+	for l, r = 0, maxLen; r < len(longString); l, r = r, r+maxLen {
+		for !utf8.RuneStart(longString[r]) {
+			r--
+		}
+		splits = append(splits, longString[l:r])
+	}
+	splits = append(splits, longString[l:])
+	return splits
 }

--- a/pkg/cookie/cookie_test.go
+++ b/pkg/cookie/cookie_test.go
@@ -1,0 +1,27 @@
+package cookie
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitCookie(t *testing.T) {
+	type args struct {
+		longString string
+		maxLen     int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"small split", args{"AAAbbbCCCdddEEEfffGGGhhhIIIjjj", 3}, []string{"AAA", "bbb", "CCC", "ddd", "EEE", "fff", "GGG", "hhh", "III", "jjj"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SplitCookie(tt.args.longString, tt.args.maxLen); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitCookie() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -26,7 +26,7 @@ type VouchClaims struct {
 	jwt.StandardClaims
 }
 
-// StandardClaims jwt.StandardClaims implimentation
+// StandardClaims jwt.StandardClaims implementation
 var StandardClaims jwt.StandardClaims
 
 // CustomClaims implementation

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -23,6 +23,8 @@ type VouchClaims struct {
 	Username     string   `json:"username"`
 	Sites        []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
 	CustomClaims map[string]interface{}
+	PAccessToken string
+	PIdToken     string
 	jwt.StandardClaims
 }
 
@@ -54,13 +56,15 @@ func populateSites() {
 }
 
 // CreateUserTokenString converts user to signed jwt
-func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims) string {
+func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims, ptokens structs.PTokens) string {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
 		u.Username,
 		Sites,
 		customClaims.Claims,
+		ptokens.PAccessToken,
+		ptokens.PIdToken,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -54,13 +54,13 @@ func populateSites() {
 }
 
 // CreateUserTokenString converts user to signed jwt
-func CreateUserTokenString(u structs.User) string {
+func CreateUserTokenString(u structs.User, customClaims map[string]interface{}) string {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
 		u.Username,
 		Sites,
-		CustomClaims,
+		customClaims,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -20,13 +20,17 @@ import (
 
 // VouchClaims jwt Claims specific to vouch
 type VouchClaims struct {
-	Username string   `json:"username"`
-	Sites    []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
+	Username     string   `json:"username"`
+	Sites        []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
+	CustomClaims map[string]interface{}
 	jwt.StandardClaims
 }
 
 // StandardClaims jwt.StandardClaims implimentation
 var StandardClaims jwt.StandardClaims
+
+// CustomClaims implementation
+var CustomClaims map[string]interface{}
 
 // Sites added to VouchClaims
 var Sites []string
@@ -56,6 +60,7 @@ func CreateUserTokenString(u structs.User) string {
 	claims := VouchClaims{
 		u.Username,
 		Sites,
+		CustomClaims,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -54,13 +54,13 @@ func populateSites() {
 }
 
 // CreateUserTokenString converts user to signed jwt
-func CreateUserTokenString(u structs.User, customClaims map[string]interface{}) string {
+func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims) string {
 	// User`token`
 	// u.PrepareUserData()
 	claims := VouchClaims{
 		u.Username,
 		Sites,
-		customClaims,
+		customClaims.Claims,
 		StandardClaims,
 	}
 

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -2,9 +2,10 @@ package jwtmanager
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -13,6 +14,10 @@ var (
 	u1 = structs.User{
 		Username: "test@testing.com",
 		Name:     "Test Name",
+	}
+	t1 = structs.PTokens{
+		PAccessToken: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjRvaXU4In0.eyJzdWIiOiJuZnlmZSIsImF1ZCI6ImltX29pY19jbGllbnQiLCJqdGkiOiJUOU4xUklkRkVzUE45enU3ZWw2eng2IiwiaXNzIjoiaHR0cHM6XC9cL3Nzby5tZXljbG91ZC5uZXQ6OTAzMSIsImlhdCI6MTM5MzczNzA3MSwiZXhwIjoxMzkzNzM3MzcxLCJub25jZSI6ImNiYTU2NjY2LTRiMTItNDU2YS04NDA3LTNkMzAyM2ZhMTAwMiIsImF0X2hhc2giOiJrdHFvZVBhc2praVY5b2Z0X3o5NnJBIn0.g1Jc9DohWFfFG3ppWfvW16ib6YBaONC5VMs8J61i5j5QLieY-mBEeVi1D3vr5IFWCfivY4hZcHtoJHgZk1qCumkAMDymsLGX-IGA7yFU8LOjUdR4IlCPlZxZ_vhqr_0gQ9pCFKDkiOv1LVv5x3YgAdhHhpZhxK6rWxojg2RddzvZ9Xi5u2V1UZ0jukwyG2d4PRzDn7WoRNDGwYOEt4qY7lv_NO2TY2eAklP-xYBWu0b9FBElapnstqbZgAXdndNs-Wqp4gyQG5D0owLzxPErR9MnpQfgNcai-PlWI_UrvoopKNbX0ai2zfkuQ-qh6Xn8zgkiaYDHzq4gzwRfwazaqA",
+		PIdToken:     "eyJhbGciOiJSUzI1NiIsImtpZCI6IjRvaXU4In0.eyJzdWIiOiJuZnlmZSIsImF1ZCI6ImltX29pY19jbGllbnQiLCJqdGkiOiJUOU4xUklkRkVzUE45enU3ZWw2eng2IiwiaXNzIjoiaHR0cHM6XC9cL3Nzby5tZXljbG91ZC5uZXQ6OTAzMSIsImlhdCI6MTM5MzczNzA3MSwiZXhwIjoxMzkzNzM3MzcxLCJub25jZSI6ImNiYTU2NjY2LTRiMTItNDU2YS04NDA3LTNkMzAyM2ZhMTAwMiIsImF0X2hhc2giOiJrdHFvZVBhc2praVY5b2Z0X3o5NnJBIn0.g1Jc9DohWFfFG3ppWfvW16ib6YBaONC5VMs8J61i5j5QLieY-mBEeVi1D3vr5IFWCfivY4hZcHtoJHgZk1qCumkAMDymsLGX-IGA7yFU8LOjUdR4IlCPlZxZ_vhqr_0gQ9pCFKDkiOv1LVv5x3YgAdhHhpZhxK6rWxojg2RddzvZ9Xi5u2V1UZ0jukwyG2d4PRzDn7WoRNDGwYOEt4qY7lv_NO2TY2eAklP-xYBWu0b9FBElapnstqbZgAXdndNs-Wqp4gyQG5D0owLzxPErR9MnpQfgNcai-PlWI_UrvoopKNbX0ai2zfkuQ-qh6Xn8zgkiaYDHzq4gzwRfwazaqA",
 	}
 
 	lc VouchClaims
@@ -36,6 +41,8 @@ func init() {
 		u1.Username,
 		Sites,
 		customClaims.Claims,
+		t1.PAccessToken,
+		t1.PIdToken,
 		StandardClaims,
 	}
 	json.Unmarshal([]byte(claimjson), &customClaims.Claims)
@@ -43,7 +50,7 @@ func init() {
 
 func TestCreateUserTokenStringAndParseToUsername(t *testing.T) {
 
-	uts := CreateUserTokenString(u1, customClaims)
+	uts := CreateUserTokenString(u1, customClaims, t1)
 	assert.NotEmpty(t, uts)
 
 	utsParsed, err := ParseTokenString(uts)
@@ -68,7 +75,7 @@ func TestClaims(t *testing.T) {
 	// log.Infof("lc d %s", d.String())
 	// lc.StandardClaims.ExpiresAt = now.Add(time.Duration(ExpiresAtMinutes) * time.Minute).Unix()
 	// log.Infof("lc expiresAt %d", now.Unix()-lc.StandardClaims.ExpiresAt)
-	uts := CreateUserTokenString(u1, customClaims)
+	uts := CreateUserTokenString(u1, customClaims, t1)
 	utsParsed, _ := ParseTokenString(uts)
 	log.Infof("utsParsed: %+v", utsParsed)
 	log.Infof("Sites: %+v", Sites)

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -1,10 +1,10 @@
 package jwtmanager
 
 import (
-	"testing"
-
+	"encoding/json"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,6 +16,15 @@ var (
 	}
 
 	lc VouchClaims
+
+	claimjson = `{
+		"sub": "f:a95afe53-60ba-4ac6-af15-fab870e72f3d:mrtester",
+		"groups": ["Website Users", "Test Group"],
+		"given_name": "Mister",
+		"family_name": "Tester",
+		"email": "mrtester@test.int"
+	}`
+	customClaims = structs.CustomClaims{}
 )
 
 func init() {
@@ -26,13 +35,15 @@ func init() {
 	lc = VouchClaims{
 		u1.Username,
 		Sites,
+		customClaims.Claims,
 		StandardClaims,
 	}
+	json.Unmarshal([]byte(claimjson), &customClaims.Claims)
 }
 
 func TestCreateUserTokenStringAndParseToUsername(t *testing.T) {
 
-	uts := CreateUserTokenString(u1)
+	uts := CreateUserTokenString(u1, customClaims)
 	assert.NotEmpty(t, uts)
 
 	utsParsed, err := ParseTokenString(uts)
@@ -57,7 +68,7 @@ func TestClaims(t *testing.T) {
 	// log.Infof("lc d %s", d.String())
 	// lc.StandardClaims.ExpiresAt = now.Add(time.Duration(ExpiresAtMinutes) * time.Minute).Unix()
 	// log.Infof("lc expiresAt %d", now.Unix()-lc.StandardClaims.ExpiresAt)
-	uts := CreateUserTokenString(u1)
+	uts := CreateUserTokenString(u1, customClaims)
 	utsParsed, _ := ParseTokenString(uts)
 	log.Infof("utsParsed: %+v", utsParsed)
 	log.Infof("Sites: %+v", Sites)

--- a/pkg/model/site.go
+++ b/pkg/model/site.go
@@ -69,13 +69,17 @@ func AllSites(sites *[]structs.Site) error {
 	return Db.View(func(tx *bolt.Tx) error {
 		if b := tx.Bucket(siteBucket); b != nil {
 			// c := b.Cursor()
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				log.Debugf("key=%s, value=%s\n", k, v)
 				s := structs.Site{}
-				Site(k, &s)
+				if err := Site(k, &s); err != nil {
+					log.Error(err)
+				}
 				*sites = append(*sites, s)
 				return nil
-			})
+			}); err != nil {
+				log.Error(err)
+			}
 			log.Debugf("sites %v", sites)
 		}
 		return nil

--- a/pkg/model/team.go
+++ b/pkg/model/team.go
@@ -83,13 +83,17 @@ func DeleteTeam(t structs.Team) error {
 func AllTeams(teams *[]structs.Team) error {
 	return Db.View(func(tx *bolt.Tx) error {
 		if b := tx.Bucket(teamBucket); b != nil {
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				log.Debugf("AllTeams ForEach key %s", k)
 				t := structs.Team{}
-				Team(k, &t)
+				if err := Team(k, &t); err != nil {
+					log.Error(err)
+				}
 				*teams = append(*teams, t)
 				return nil
-			})
+			}); err != nil {
+				log.Error(err)
+			}
 			log.Debugf("teams %+v", *teams)
 			return nil
 		}

--- a/pkg/model/user.go
+++ b/pkg/model/user.go
@@ -81,13 +81,17 @@ func User(key []byte, u *structs.User) error {
 func AllUsers(users *[]structs.User) error {
 	return Db.View(func(tx *bolt.Tx) error {
 		if b := tx.Bucket(userBucket); b != nil {
-			b.ForEach(func(k, v []byte) error {
+			if err := b.ForEach(func(k, v []byte) error {
 				log.Debugf("key=%s, value=%s\n", k, v)
 				u := structs.User{}
-				User(k, &u)
+				if err := User(k, &u); err != nil {
+					log.Error(err)
+				}
 				*users = append(*users, u)
 				return nil
-			})
+			}); err != nil {
+				log.Error(err)
+			}
 			log.Debugf("users %v", users)
 			return nil
 		}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -1,5 +1,10 @@
 package structs
 
+// Temporary struct storing custom claims until JWT creation.
+type CustomClaims struct {
+	Claims map[string]interface{}
+}
+
 // UserI each *User struct must prepare the data for being placed in the JWT
 type UserI interface {
 	PrepareUserData()

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -110,3 +110,8 @@ type Site struct {
 	LastUpdate int64  `json:"lastupdate"`
 	ID         int    `json:"id" mapstructure:"id"`
 }
+
+type PTokens struct {
+	PAccessToken string
+	PIdToken     string
+}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -15,12 +15,12 @@ type User struct {
 	// TODO: set Provider here so that we can pass it to db
 	// populated by db (via mapstructure) or from provider (via json)
 	// Provider   string `json:"provider",mapstructure:"provider"`
-	Username   string `json:"username",mapstructure:"username"`
-	Name       string `json:"name",mapstructure:"name"`
-	Email      string `json:"email",mapstructure:"email"`
+	Username   string `json:"username" mapstructure:"username"`
+	Name       string `json:"name" mapstructure:"name"`
+	Email      string `json:"email" mapstructure:"email"`
 	CreatedOn  int64  `json:"createdon"`
 	LastUpdate int64  `json:"lastupdate"`
-	ID         int    `json:"id",mapstructure:"id"`
+	ID         int    `json:"id" mapstructure:"id"`
 	// jwt.StandardClaims
 }
 
@@ -95,12 +95,12 @@ func (u *IndieAuthUser) PrepareUserData() {
 
 // Team has members and provides acess to sites
 type Team struct {
-	Name       string   `json:"name",mapstructure:"name"`
-	Members    []string `json:"members",mapstructure:"members"` // just the emails
-	Sites      []string `json:"sites",mapstructure:"sites"`     // just the domains
-	CreatedOn  int64    `json:"createdon",mapstructure:"createdon"`
-	LastUpdate int64    `json:"lastupdate",mapstructure:"lastupdate"`
-	ID         int      `json:"id",mapstructure:"id"`
+	Name       string   `json:"name" mapstructure:"name"`
+	Members    []string `json:"members" mapstructure:"members"` // just the emails
+	Sites      []string `json:"sites" mapstructure:"sites"`     // just the domains
+	CreatedOn  int64    `json:"createdon" mapstructure:"createdon"`
+	LastUpdate int64    `json:"lastupdate" mapstructure:"lastupdate"`
+	ID         int      `json:"id" mapstructure:"id"`
 }
 
 // Site is the basic unit of auth
@@ -108,5 +108,5 @@ type Site struct {
 	Domain     string `json:"domain"`
 	CreatedOn  int64  `json:"createdon"`
 	LastUpdate int64  `json:"lastupdate"`
-	ID         int    `json:"id",mapstructure:"id"`
+	ID         int    `json:"id" mapstructure:"id"`
 }

--- a/pkg/transciever/client.go
+++ b/pkg/transciever/client.go
@@ -226,6 +226,7 @@ func serveWs(hub *Hub, w http.ResponseWriter, r *http.Request) {
 	client.readPump()
 }
 
+// An echo function
 func Echo(conn *websocket.Conn) error {
 	messageType, r, err := conn.NextReader()
 	if err != nil {


### PR DESCRIPTION
With OpenResty, we can offload all authorization functions from vouch and keep it lean and focused.  I think we should provide a couple of common examples to provide to users.  
The readme is starting to get busy... perhaps it is time for a wiki, and we can add it there instead?

