### PR TITLE
Load templates relative to VOUCH_ROOT.

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -48,7 +49,7 @@ const (
 
 var (
 	// Templates
-	indexTemplate = template.Must(template.ParseFiles("./templates/index.tmpl"))
+	indexTemplate = template.Must(template.ParseFiles(filepath.Join(cfg.RootDir, "templates/index.tmpl")))
 
 	// http://www.gorillatoolkit.org/pkg/sessions
 	sessstore = sessions.NewCookieStore([]byte(cfg.Cfg.Session.Key))

--- a/main.go
+++ b/main.go
@@ -73,15 +73,16 @@ func main() {
 	healthH := http.HandlerFunc(handlers.HealthcheckHandler)
 	muxR.HandleFunc("/healthcheck", timelog.TimeLog(healthH))
 
+	// setup static
+	sPath, err := filepath.Abs(cfg.RootDir + staticDir)
 	if logger.Desugar().Core().Enabled(zap.DebugLevel) {
-		path, err := filepath.Abs(staticDir)
 		if err != nil {
-			logger.Errorf("couldn't find static assets at %s", path)
+			logger.Errorf("couldn't find static assets at %s", sPath)
 		}
-		logger.Debugf("serving static files from %s", path)
+		logger.Debugf("serving static files from %s", sPath)
 	}
 	// https://golangcode.com/serve-static-assets-using-the-mux-router/
-	muxR.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir("."+staticDir))))
+	muxR.PathPrefix(staticDir).Handler(http.StripPrefix(staticDir, http.FileServer(http.Dir(sPath))))
 
 	if cfg.Cfg.WebApp {
 		logger.Info("enabling websocket")

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -130,7 +131,8 @@ var (
 	// RequiredOptions must have these fields set for minimum viable config
 	RequiredOptions = []string{"oauth.provider", "oauth.client_id"}
 
-	secretFile = os.Getenv("VOUCH_ROOT") + "config/secret"
+	RootDir    string
+	secretFile string
 
 	cmdLineConfig *string
 
@@ -154,6 +156,19 @@ func init() {
 	help := flag.Bool("help", false, "show usage")
 	cmdLineConfig = flag.String("config", "", "specify alternate .yml file as command line arg")
 	flag.Parse()
+
+	vouchRoot := os.Getenv(Branding.UCName + "_ROOT")
+	if vouchRoot != "" {
+		RootDir, _ = filepath.Abs(vouchRoot)
+	} else {
+		ex, errEx := os.Executable()
+		if errEx != nil {
+			panic(errEx)
+		}
+		RootDir, _ = filepath.Abs(ex)
+	}
+
+	secretFile = filepath.Join(RootDir, "config/secret")
 
 	atom = zap.NewAtomicLevel()
 	encoderCfg := zap.NewProductionEncoderConfig()
@@ -240,19 +255,22 @@ func InitForTestPurposes() {
 func ParseConfig() {
 	log.Debug("opening config")
 
-	if os.Getenv(Branding.UCName+"_CONFIG") != "" {
-		log.Infof("config file loaded from environmental variable %s: %s", Branding.UCName+"_CONFIG", os.Getenv(Branding.UCName+"_CONFIG"))
-		viper.SetConfigFile(os.Getenv(Branding.UCName + "_CONFIG"))
+	configEnv := os.Getenv(Branding.UCName + "_CONFIG")
+
+	if configEnv != "" {
+		log.Infof("config file loaded from environmental variable %s: %s", Branding.UCName+"_CONFIG", configEnv)
+		configFile, _ := filepath.Abs(configEnv)
+		viper.SetConfigFile(configFile)
 	} else if *cmdLineConfig != "" {
 		log.Infof("config file set on commandline: %s", *cmdLineConfig)
 		viper.AddConfigPath("/")
-		viper.AddConfigPath(os.Getenv(Branding.UCName + "_ROOT"))
-		viper.AddConfigPath(os.Getenv(Branding.UCName+"_ROOT") + "config")
+		viper.AddConfigPath(RootDir)
+		viper.AddConfigPath(filepath.Join(RootDir, "config"))
 		viper.SetConfigFile(*cmdLineConfig)
 	} else {
 		viper.SetConfigName("config")
 		viper.SetConfigType("yaml")
-		viper.AddConfigPath(os.Getenv(Branding.UCName+"_ROOT") + "config")
+		viper.AddConfigPath(filepath.Join(RootDir, "config"))
 	}
 	err := viper.ReadInConfig() // Find and read the config file
 	if err != nil {             // Handle errors reading the config file
@@ -270,7 +288,7 @@ func ParseConfig() {
 		}
 
 		if len(oldConfig.Domains) != 0 {
-			log.Errorf(`						
+			log.Errorf(`
 
 IMPORTANT!
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -6,7 +6,7 @@ package model
 import (
 	"errors"
 	"flag"
-	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -30,7 +30,7 @@ var (
 	userBucket = []byte("users")
 	teamBucket = []byte("teams")
 	siteBucket = []byte("sites")
-	dbpath     = os.Getenv("VOUCH_ROOT") + cfg.Cfg.DB.File
+	dbpath     = filepath.Join(cfg.RootDir, cfg.Cfg.DB.File)
 
 	log = cfg.Cfg.Logger
 )


### PR DESCRIPTION
First pass fix for https://github.com/vouch/vouch-proxy/issues/119

Sets a `RootDir` variable to either the value of the `VOUCH_ROOT` env var or to the current executables directory.

This is then used when loading the secrets file, DB and the template.

Also replaces some path concatenations with `filepath.Join()` which is better suited to handling path components with/without slashes.