### PR TITLE
test for valid provider; preserve username

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -315,6 +315,14 @@ func Get(key string) string {
 
 // BasicTest just a quick sanity check to see if the config is sound
 func BasicTest() error {
+	if GenOAuth.Provider != Providers.Google &&
+       GenOAuth.Provider != Providers.GitHub &&
+       GenOAuth.Provider != Providers.IndieAuth &&
+       GenOAuth.Provider != Providers.ADFS &&
+       GenOAuth.Provider != Providers.OIDC {
+            return errors.New("configuration error: Unkown oauth provider: "+ GenOAuth.Provider)
+    }
+
 	for _, opt := range RequiredOptions {
 		if !viper.IsSet(opt) {
 			return errors.New("configuration error: required configuration option " + opt + " is not set")
@@ -530,6 +538,7 @@ func SetDefaults() {
 			setDefaultsADFS()
 			configureOAuthClient()
 		} else {
+            // IndieAuth, OIDC
 			configureOAuthClient()
 		}
 	}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -26,7 +26,9 @@ type User struct {
 
 // PrepareUserData implement PersonalData interface
 func (u *User) PrepareUserData() {
-	u.Username = u.Email
+	if u.Username == "" {
+	    u.Username = u.Email
+    }
 }
 
 // GoogleUser is a retrieved and authentiacted user from Google.


### PR DESCRIPTION
Require a valid provider name string to startup
When fetching userInfo, only use the email address as the username if the name is empty.