### PR TITLE
Create OpenStax Accounts provider

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -315,6 +315,14 @@ func Get(key string) string {
 
 // BasicTest just a quick sanity check to see if the config is sound
 func BasicTest() error {
+	if GenOAuth.Provider != Providers.Google &&
+       GenOAuth.Provider != Providers.GitHub &&
+       GenOAuth.Provider != Providers.IndieAuth &&
+       GenOAuth.Provider != Providers.ADFS &&
+       GenOAuth.Provider != Providers.OIDC {
+            return errors.New("configuration error: Unkown oauth provider: "+ GenOAuth.Provider)
+    }
+
 	for _, opt := range RequiredOptions {
 		if !viper.IsSet(opt) {
 			return errors.New("configuration error: required configuration option " + opt + " is not set")
@@ -530,6 +538,7 @@ func SetDefaults() {
 			setDefaultsADFS()
 			configureOAuthClient()
 		} else {
+            // IndieAuth, OIDC
 			configureOAuthClient()
 		}
 	}

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -91,6 +91,7 @@ type OAuthProviders struct {
 	IndieAuth string
 	ADFS      string
 	OIDC      string
+	OpenStax  string
 }
 
 type branding struct {
@@ -126,6 +127,7 @@ var (
 		IndieAuth: "indieauth",
 		ADFS:      "adfs",
 		OIDC:      "oidc",
+		OpenStax:  "openstax",
 	}
 
 	// RequiredOptions must have these fields set for minimum viable config
@@ -319,7 +321,8 @@ func BasicTest() error {
        GenOAuth.Provider != Providers.GitHub &&
        GenOAuth.Provider != Providers.IndieAuth &&
        GenOAuth.Provider != Providers.ADFS &&
-       GenOAuth.Provider != Providers.OIDC {
+       GenOAuth.Provider != Providers.OIDC &&
+       GenOAuth.Provider != Providers.OpenStax {
             return errors.New("configuration error: Unkown oauth provider: "+ GenOAuth.Provider)
     }
 
@@ -538,7 +541,7 @@ func SetDefaults() {
 			setDefaultsADFS()
 			configureOAuthClient()
 		} else {
-            // IndieAuth, OIDC
+            // IndieAuth, OIDC, OpenStax
 			configureOAuthClient()
 		}
 	}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -26,7 +26,9 @@ type User struct {
 
 // PrepareUserData implement PersonalData interface
 func (u *User) PrepareUserData() {
-	u.Username = u.Email
+	if u.Username == "" {
+	    u.Username = u.Email
+    }
 }
 
 // GoogleUser is a retrieved and authentiacted user from Google.

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -95,6 +95,31 @@ func (u *IndieAuthUser) PrepareUserData() {
 	u.Username = u.URL
 }
 
+type Contact struct {
+    Type     string `json:"type"`
+    Value    string `json:"value"`
+    Verified bool `json:"is_verified"`
+}
+
+//OpenStaxUser is a retrieved and authenticated user from OpenStax Accounts
+type OpenStaxUser struct {
+    User
+    Contacts []Contact `json:"contact_infos"`
+}
+
+// PrepareUserData implement PersonalData interface
+func (u *OpenStaxUser) PrepareUserData() {
+    if u.Email == "" {
+        // assuming first contact of type "EmailAddress"
+        for _, c := range u.Contacts {
+            if c.Type == "EmailAddress" && c.Verified {
+                u.Email = c.Value
+                break
+            }
+        }
+    }
+}
+
 // Team has members and provides acess to sites
 type Team struct {
 	Name       string   `json:"name" mapstructure:"name"`


### PR DESCRIPTION
We have a oauth2 provider (OpenStax Accounts: https://github.com/openstax/accounts) that is _almost_ an openid provider. With a couple small tweaks, I can authenticate against it. The primary 
problem is the lack of an `id_token` in the return from the `token` endpoint. Secondarily, the userinfo is only accidentally matching to OpenId userinfo - create some mappings like the other cases in the code.
Not sure how to generalize either of those things, to be honest.

This PR also contains the cleanups from my previous PR: If you want to commit them separately, I'll rebase this one.