### PR TITLE
Before this, we didn't have do.sh in the final image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -23,6 +23,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 COPY templates/ templates/
 # see note for /static in main.go
 COPY static /static
+COPY do.sh /do.sh
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]


### PR DESCRIPTION
This made following the steps to use do.sh to generate a redacted
configuration file impossible.