### PR TITLE
add semicolon after "access_by_lua_file" directive

### DIFF
--- a/examples/OpenResty/conf.d/app1.yourdomain.com.conf
+++ b/examples/OpenResty/conf.d/app1.yourdomain.com.conf
@@ -63,6 +63,6 @@ server {
       #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
 
       # Authenticate the application by user
-      access_by_lua_file  lua/user_auth.lua
+      access_by_lua_file  lua/user_auth.lua;
     }
 }


### PR DESCRIPTION
OpenResty service cannot be restarted/reloaded if semicolon is missing at the end of the "access_by_lua_file" directive