### PR TITLE
Added missing check for homeassistant in BasicTest

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -351,6 +351,7 @@ func BasicTest() error {
 	if GenOAuth.Provider != Providers.Google &&
 		GenOAuth.Provider != Providers.GitHub &&
 		GenOAuth.Provider != Providers.IndieAuth &&
+		GenOAuth.Provider != Providers.HomeAssistant &&
 		GenOAuth.Provider != Providers.ADFS &&
 		GenOAuth.Provider != Providers.OIDC &&
 		GenOAuth.Provider != Providers.OpenStax {


### PR DESCRIPTION
I noticed the BasicTest executed to validate the configuration was missing an entry for HomeAssistant. This caused an "unknown oauth provider" error message, so it was not usable. Adding the check solved this issue.