### PR TITLE
Fix adfs mapclaims

### DIFF
--- a/examples/OpenResty/conf.d/app2.yourdomain.com.conf
+++ b/examples/OpenResty/conf.d/app2.yourdomain.com.conf
@@ -25,7 +25,7 @@ server {
       auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
 
       # optionally add X-Vouch-IdP-Claims-* custom claims you are tracking
-      auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+      auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_group;
       #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
       # optinally add X-Vouch-IdP-AccessToken or X-Vouch-IdP-IdToken
       #    auth_request_set $auth_resp_x_vouch_idp_accesstoken $upstream_http_x_vouch_idp_accesstoken;
@@ -56,7 +56,7 @@ server {
       # set user header (usually an email)
       proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
       # optionally pass any custom claims you are tracking
-      proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+      proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_group;
       #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
       # optionally pass the accesstoken or idtoken
       #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;

--- a/examples/OpenResty/lua/group_auth.lua
+++ b/examples/OpenResty/lua/group_auth.lua
@@ -4,14 +4,14 @@
 -- ==============================
 -- Validate that a user is in a group
 local authorized_groups = Set {
-    "Domain Users",
-    "Website Users"
+    "CN=Domain Users,CN=Users,DC=Contoso,DC=com",
+    "CN=Website Users,CN=Users,DC=Contoso,DC=com"
 }
 -- Verify the variable exists
 if ngx.var.auth_resp_x_vouch_idp_claims_groups then
     -- Check if the found user is in the allowed_users table
     local cjson = require("cjson")
-    local groups = cjson.decode(ngx.var.auth_resp_x_vouch_idp_claims_groups)
+    local groups = cjson.decode("[" .. ngx.var.auth_resp_x_vouch_idp_claims_groups .. "]")
     local found = false
     -- Parse the groups and check if they match any of our authorized groups
     for i, group in ipairs(groups) do

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -812,15 +812,28 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *stru
 		log.Error(err)
 		return nil
 	}
+	log.Debugf("idToken: %+v", string(idToken))
 
 	adfsUser := structs.ADFSUser{}
 	json.Unmarshal([]byte(idToken), &adfsUser)
 	log.Infof("adfs adfsUser: %+v", adfsUser)
-	if err = mapClaims(data, customClaims); err != nil {
+	// data contains an access token, refresh token, and id token
+	// Please note that in order for custom claims to work you MUST set allatclaims in ADFS to be passed
+	// https://oktotechnologies.ca/2018/08/26/adfs-openidconnect-configuration/
+	if err = mapClaims([]byte(idToken), customClaims); err != nil {
 		log.Error(err)
 		return err
 	}
 	adfsUser.PrepareUserData()
+	var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+
+	if len(adfsUser.Email) == 0 {
+		// If the email is blank, we will try to determine if the UPN is an email.
+		if rxEmail.MatchString(adfsUser.UPN) {
+			// Set the email from UPN if there is a valid email present.
+			adfsUser.Email = adfsUser.UPN
+		}
+	}
 	user.Username = adfsUser.Username
 	user.Email = adfsUser.Email
 	log.Debugf("User Obj: %+v", user)


### PR DESCRIPTION
In reference to the discussion in #158, this fixed mapclaims issue.

Some explanation:
The 'data' return from the user endpoint in adfs returns an Access Token, Refresh Token, and Id Token.  So in order to map claims, you must parse the ID token into a JSON object, then map claims against it.  In my testing, adfs only drops the custom claims (such as groups, etc) into either access or ID token if you use the 'allatclaims' in the Client Permissions area of the app.  Therefore, in order to properly use claims from adfs, this permission MUST be set.

If allatclaims is not set, I've added logic to parse the UPN to determine if it is a valid email address, and if it is, populate the email address for the adfs user. This ensures that even if no custom claims are passed down, we can still validate the user against the authorized domains.

Additionally, I did a quick fix on the logic for the openresty groups example that I just noticed wasn't 100% correct.