### PR TITLE
Fix missing HomeAssistant provider check

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -351,6 +351,7 @@ func BasicTest() error {
 	if GenOAuth.Provider != Providers.Google &&
 		GenOAuth.Provider != Providers.GitHub &&
 		GenOAuth.Provider != Providers.IndieAuth &&
+		GenOAuth.Provider != Providers.HomeAssistant &&
 		GenOAuth.Provider != Providers.ADFS &&
 		GenOAuth.Provider != Providers.OIDC &&
 		GenOAuth.Provider != Providers.OpenStax {


### PR DESCRIPTION
`Providers.HomeAssistant` check missing from recent PR #140 and commit cda7bd781e2c89157276be640f15e9039154111d. Causes config validation error on latest versions.