### PR TITLE
replace colon in claim headers to prevent issues with namespaced claims

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -208,7 +208,7 @@ func ValidateRequestHandler(w http.ResponseWriter, r *http.Request) {
 				// Check for matching claim
 				if cv == k {
 					log.Debug("Found matching claim key: ", k)
-					customHeader := strings.Join([]string{cfg.Cfg.Headers.ClaimHeader, k}, "")
+					customHeader := strings.Replace(strings.Join([]string{cfg.Cfg.Headers.ClaimHeader, k}, ""), ":", "-", -1)
 					// convert to string
 					val := fmt.Sprint(v)
 					if reflect.TypeOf(val).Kind() == reflect.String {


### PR DESCRIPTION
Workaround/Fix for #183. Please see #183 for a more detailed description of the issue. 

This PR rewrites any colon in a claim key to a dash. This resolves the issue that the remainder after the colon would be interpreted as part of the value instead of the key.

given a claim `custom:roles` with value `administrator`
**expected** result: a header `X-Vouch-IdP-Claims-custom:roles` with value `administrator`
**actual** result: a header  `X-Vouch-IdP-Claims-custom` with value `roles: administrator`
**patched** result: a header  `X-Vouch-IdP-Claims-custom-roles` with value `administrator`

This PR is mostly provided for other users until a proper fix has been made, as anyone using custom claims with AWS Cognito (and possibly other IdPs) can easily run into the issue. 