### PR TITLE
Fix domain checks

### DIFF
--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -14,12 +14,17 @@ func init() {
 	sort.Sort(ByLengthDesc(domains))
 }
 
+func Refresh() {
+	domains = cfg.Cfg.Domains
+	sort.Sort(ByLengthDesc(domains))
+}
+
 // Matches returns one of the domains we're configured for
 // TODO return all matches
 // Matches return the first match of the
 func Matches(s string) string {
 	for i, v := range domains {
-		if strings.Contains(s, v) {
+		if s == v || strings.HasSuffix(s, "." + v) {
 			log.Debugf("domain %s matched array value at [%d]=%v", s, i, v)
 			return v
 		}
@@ -28,9 +33,15 @@ func Matches(s string) string {
 	return ""
 }
 
-// IsUnderManagement check if string contains a vouch managed domain
-func IsUnderManagement(s string) bool {
-	match := Matches(s)
+// IsUnderManagement check if an email is under vouch-managed domain
+func IsUnderManagement(email string) bool {
+	split := strings.Split(email, "@")
+	if len(split) != 2 {
+		log.Warnf("not a valid email: %s", email)
+		return false
+	}
+
+	match := Matches(split[1])
 	if match != "" {
 		return true
 	}

--- a/pkg/domains/domains_test.go
+++ b/pkg/domains/domains_test.go
@@ -1,0 +1,42 @@
+package domains
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+)
+
+func init() {
+	cfg.InitForTestPurposes()
+	cfg.Cfg.Domains = []string{"vouch.github.io", "sub.test.mydomain.com", "test.mydomain.com"}
+	Refresh()
+}
+
+func TestIsUnderManagement(t *testing.T) {
+	assert.True(t, IsUnderManagement("test@vouch.github.io"))
+	assert.True(t, IsUnderManagement("test@sub.vouch.github.io"))
+	assert.True(t, IsUnderManagement("test@test.mydomain.com"))
+	assert.True(t, IsUnderManagement("test@sub.test.mydomain.com"))
+
+	assert.False(t, IsUnderManagement("test@example.com"))
+	assert.False(t, IsUnderManagement("vouch.github.io@example.com"))
+	assert.False(t, IsUnderManagement("test-vouch.github.io@example.com"))
+	assert.False(t, IsUnderManagement("test@vouch.github.io.com"))
+}
+
+func TestMatches(t *testing.T) {
+	// Full email should not be accepted
+	assert.Equal(t, "", Matches("test@vouch.github.io"))
+	
+	assert.Equal(t, "vouch.github.io", Matches("vouch.github.io"))
+	assert.Equal(t, "vouch.github.io", Matches("sub.vouch.github.io"))
+	assert.Equal(t, "", Matches("a-different-vouch.github.io"))
+
+	assert.Equal(t, "", Matches("mydomain.com"))
+	
+	assert.Equal(t, "test.mydomain.com", Matches("test.mydomain.com"))
+	assert.Equal(t, "sub.test.mydomain.com", Matches("sub.test.mydomain.com"))
+	assert.Equal(t, "sub.test.mydomain.com", Matches("subsub.sub.test.mydomain.com"))
+	assert.Equal(t, "test.mydomain.com", Matches("other.test.mydomain.com"))
+}


### PR DESCRIPTION
Fixes #198

- given a domain `vouch.github.io` as config value `vouch.domains` and user with email `vouch.github.io@yahoo.com`
  * expected result: User won't be authorised.
  * actual result: User is authorised.
  * patched result: User won't be authorised.

- given a domain `easy.vouch.io` as config value `vouch.domains` and user with email `test@uneasy.vouch.io`
  * expected result: User won't be authorised.
  * actual result: User is authorised.
  * patched result: User won't be authorised.

From looking at the code, `domains.IsUnderManagement(user.Email)` which uses `domain.Matches()` method will create the misbehaviour described above. The PR should fix this.
