### PR TITLE
Authorize by GitHub org and or team membership

### DIFF
--- a/config/config.yml_example_github
+++ b/config/config.yml_example_github
@@ -15,6 +15,16 @@ vouch:
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at GitHub
   # allowAllUsers: true
 
+  # set teamWhitelist: to list of teams and/or GitHub organizations
+  # When putting an organization id without a slash, it will allow all (public) members from the organization.
+  # The client will try to read the private organization membership using the client credentials, if that's not possible
+  # due to access restriction, it will try to evaluate the publicly visible membership.
+  # Allowing members form a specific team can be configured by qualifying the team with the organization, separated by
+  # a slash.
+  # teamWhitelist:
+  # - myOrg
+  # - myOrg/myTeam
+
 oauth:
   # create a new OAuth application at:
   # https://github.com/settings/applications/new

--- a/config/config.yml_example_github
+++ b/config/config.yml_example_github
@@ -24,6 +24,7 @@ vouch:
   # teamWhitelist:
   # - myOrg
   # - myOrg/myTeam
+  # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included
 
 oauth:
   # create a new OAuth application at:

--- a/config/config.yml_example_github_enterprise
+++ b/config/config.yml_example_github_enterprise
@@ -15,6 +15,15 @@ vouch:
   # instead of setting specific domains you may prefer to allow all users...
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
   # allowAllUsers: true
+  # set teamWhitelist: to list of teams and/or GitHub organizations
+  # When putting an organization id without a slash, it will allow all (public) members from the organization.
+  # The client will try to read the private organization membership using the client credentials, if that's not possible
+  # due to access restriction, it will try to evaluate the publicly visible membership.
+  # Allowing members form a specific team can be configured by qualifying the team with the organization, separated by
+  # a slash.
+  # teamWhitelist:
+  # - myOrg
+  # - myOrg/myTeam
 
 oauth:
   # create a new OAuth application at:
@@ -25,6 +34,10 @@ oauth:
   auth_url: https://githubenterprise.yoursite.com/login/oauth/authorize
   token_url: https://githubenterprise.yoursite.com/login/oauth/access_token
   user_info_url: https://githubenterprise.yoursite.com/api/v3/user?access_token=
+  # relevant only if teamWhitelist is configured; colon-prefixed parts are parameters that
+  # will be replaced with the respective values.
+  user_team_url: https://githubenterprise.yoursite.com/api/v3/orgs/:org_id/teams/:team_slug/memberships/:username?access_token=
+  user_org_url: https://githubenterprise.yoursite.com/api/v3/orgs/:org_id/members/:username?access_token=
   # these GitHub OAuth defaults are set for you..
   # scopes:
   #   - user

--- a/config/config.yml_example_github_enterprise
+++ b/config/config.yml_example_github_enterprise
@@ -24,6 +24,7 @@ vouch:
   # teamWhitelist:
   # - myOrg
   # - myOrg/myTeam
+  # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included
 
 oauth:
   # create a new OAuth application at:
@@ -41,3 +42,4 @@ oauth:
   # these GitHub OAuth defaults are set for you..
   # scopes:
   #   - user
+  # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included

--- a/handlers/adfs/adfs.go
+++ b/handlers/adfs/adfs.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 )
 
+type Handler struct{}
+
 type adfsTokenRes struct {
 	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
@@ -26,7 +28,7 @@ var (
 )
 
 // More info: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers#supported-scenarios
-func GetUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
 	code := r.URL.Query().Get("code")
 	log.Debugf("code: %s", code)
 

--- a/handlers/adfs/adfs.go
+++ b/handlers/adfs/adfs.go
@@ -1,0 +1,110 @@
+package adfs
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type adfsTokenRes struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	IDToken     string `json:"id_token"`
+	ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
+}
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+// More info: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers#supported-scenarios
+func GetUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	code := r.URL.Query().Get("code")
+	log.Debugf("code: %s", code)
+
+	formData := url.Values{}
+	formData.Set("code", code)
+	formData.Set("grant_type", "authorization_code")
+	formData.Set("resource", cfg.GenOAuth.RedirectURL)
+	formData.Set("client_id", cfg.GenOAuth.ClientID)
+	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
+	if cfg.GenOAuth.ClientSecret != "" {
+		formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
+	}
+	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Content-Length", strconv.Itoa(len(formData.Encode())))
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	userinfo, err := client.Do(req)
+
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	tokenRes := adfsTokenRes{}
+
+	if err := json.Unmarshal(data, &tokenRes); err != nil {
+		log.Errorf("oauth2: cannot fetch token: %v", err)
+		return nil
+	}
+
+	ptokens.PAccessToken = string(tokenRes.AccessToken)
+	ptokens.PIdToken = string(tokenRes.IDToken)
+
+	s := strings.Split(tokenRes.IDToken, ".")
+	if len(s) < 2 {
+		log.Error("jws: invalid token received")
+		return nil
+	}
+
+	idToken, err := base64.RawURLEncoding.DecodeString(s[1])
+	if err != nil {
+		log.Error(err)
+		return nil
+	}
+	log.Debugf("idToken: %+v", string(idToken))
+
+	adfsUser := structs.ADFSUser{}
+	json.Unmarshal([]byte(idToken), &adfsUser)
+	log.Infof("adfs adfsUser: %+v", adfsUser)
+	// data contains an access token, refresh token, and id token
+	// Please note that in order for custom claims to work you MUST set allatclaims in ADFS to be passed
+	// https://oktotechnologies.ca/2018/08/26/adfs-openidconnect-configuration/
+	if err = common.MapClaims([]byte(idToken), customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	adfsUser.PrepareUserData()
+	var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+
+	if len(adfsUser.Email) == 0 {
+		// If the email is blank, we will try to determine if the UPN is an email.
+		if rxEmail.MatchString(adfsUser.UPN) {
+			// Set the email from UPN if there is a valid email present.
+			adfsUser.Email = adfsUser.UPN
+		}
+	}
+	user.Username = adfsUser.Username
+	user.Email = adfsUser.Email
+	log.Debugf("User Obj: %+v", user)
+	return nil
+}

--- a/handlers/common/common.go
+++ b/handlers/common/common.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+)
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+func MapClaims(claims []byte, customClaims *structs.CustomClaims) error {
+	// Create a struct that contains the claims that we want to store from the config.
+	var f interface{}
+	err := json.Unmarshal(claims, &f)
+	if err != nil {
+		log.Error("Error unmarshaling claims")
+		return err
+	}
+	m := f.(map[string]interface{})
+	for k := range m {
+		var found = false
+		for _, e := range cfg.Cfg.Headers.Claims {
+			if k == e {
+				found = true
+			}
+		}
+		if found == false {
+			delete(m, k)
+		}
+	}
+	customClaims.Claims = m
+	return nil
+}

--- a/handlers/common/common.go
+++ b/handlers/common/common.go
@@ -1,14 +1,40 @@
 package common
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
+	"golang.org/x/oauth2"
+	"net/http"
 )
 
 var (
 	log = cfg.Cfg.Logger
 )
+
+func PrepareTokensAndClient(r *http.Request, ptokens *structs.PTokens, setpid bool) (error, *http.Client, *oauth2.Token) {
+	providerToken, err := cfg.OAuthClient.Exchange(context.TODO(), r.URL.Query().Get("code"))
+	if err != nil {
+		return err, nil, nil
+	}
+	ptokens.PAccessToken = providerToken.AccessToken
+
+	if setpid {
+		if providerToken.Extra("id_token") != nil {
+			// Certain providers (eg. gitea) don't provide an id_token
+			// and it's not neccessary for the authentication phase
+			ptokens.PIdToken = providerToken.Extra("id_token").(string)
+		} else {
+			log.Debugf("id_token missing - may not be supported by this provider")
+		}
+	}
+
+	log.Debugf("ptokens: %+v", ptokens)
+
+	client := cfg.OAuthClient.Client(context.TODO(), providerToken)
+	return err, client, providerToken
+}
 
 func MapClaims(claims []byte, customClaims *structs.CustomClaims) error {
 	// Create a struct that contains the claims that we want to store from the config.

--- a/handlers/github/github.go
+++ b/handlers/github/github.go
@@ -17,8 +17,12 @@ var (
 
 // github
 // https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
-func GetUserInfoFromGitHub(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
-
+func GetUserInfoFromGitHub(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, client, ptoken := common.PrepareTokensAndClient(r, ptokens, true)
+	if err != nil {
+		// http.Error(w, err.Error(), http.StatusBadRequest)
+		return err
+	}
 	log.Errorf("ptoken.AccessToken: %s", ptoken.AccessToken)
 	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL + ptoken.AccessToken)
 	if err != nil {

--- a/handlers/github/github.go
+++ b/handlers/github/github.go
@@ -11,14 +11,18 @@ import (
 	"strings"
 )
 
+type Handler struct {
+	PrepareTokensAndClient func(*http.Request, *structs.PTokens, bool) (error, *http.Client, *oauth2.Token)
+}
+
 var (
 	log = cfg.Cfg.Logger
 )
 
 // github
 // https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
-func GetUserInfoFromGitHub(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
-	err, client, ptoken := common.PrepareTokensAndClient(r, ptokens, true)
+func (me Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, client, ptoken := me.PrepareTokensAndClient(r, ptokens, true)
 	if err != nil {
 		// http.Error(w, err.Error(), http.StatusBadRequest)
 		return err

--- a/handlers/github/github.go
+++ b/handlers/github/github.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
@@ -123,11 +124,14 @@ func getOrgMembershipStateFromGitHub(client *http.Client, user *structs.User, or
 	}
 
 	if orgMembershipResp.StatusCode == 204 {
+		log.Debug("getOrgMembershipStateFromGitHub isMember: true")
 		return nil, true
 	} else if orgMembershipResp.StatusCode == 404 {
+		log.Debug("getOrgMembershipStateFromGitHub isMember: false")
 		return nil, false
 	} else {
-		return nil, false
+		log.Errorf("getOrgMembershipStateFromGitHub: unexpected status code %d", orgMembershipResp.StatusCode)
+		return errors.New("Unexpected response status " + orgMembershipResp.Status), false
 	}
 }
 
@@ -154,7 +158,11 @@ func getTeamMembershipStateFromGitHub(client *http.Client, user *structs.User, o
 		log.Debug("getTeamMembershipStateFromGitHub ghTeamState")
 		log.Debug(ghTeamState)
 		return nil, ghTeamState.State == "active"
-	} else {
+	} else if membershipStateResp.StatusCode == 404 {
+		log.Debug("getTeamMembershipStateFromGitHub isMember: false")
 		return nil, false
+	} else {
+		log.Errorf("getTeamMembershipStateFromGitHub: unexpected status code %d", membershipStateResp.StatusCode)
+		return errors.New("Unexpected response status " + membershipStateResp.Status), false
 	}
 }

--- a/handlers/github/github.go
+++ b/handlers/github/github.go
@@ -1,0 +1,152 @@
+package github
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+// github
+// https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
+func GetUserInfoFromGitHub(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
+
+	log.Errorf("ptoken.AccessToken: %s", ptoken.AccessToken)
+	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL + ptoken.AccessToken)
+	if err != nil {
+		// http.Error(w, err.Error(), http.StatusBadRequest)
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("github userinfo body: %s", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	ghUser := structs.GitHubUser{}
+	if err = json.Unmarshal(data, &ghUser); err != nil {
+		log.Error(err)
+		return err
+	}
+	log.Debug("getUserInfoFromGitHub ghUser")
+	log.Debug(ghUser)
+	log.Debug("getUserInfoFromGitHub user")
+	log.Debug(user)
+
+	ghUser.PrepareUserData()
+	user.Email = ghUser.Email
+	user.Name = ghUser.Name
+	user.Username = ghUser.Username
+	user.ID = ghUser.ID
+
+	// user = &ghUser.User
+
+	toOrgAndTeam := func(orgAndTeam string) (string, string) {
+		split := strings.Split(orgAndTeam, "/")
+		if len(split) == 1 {
+			// only organization given
+			return orgAndTeam, ""
+		} else if len(split) == 2 {
+			return split[0], split[1]
+		} else {
+			return "", ""
+		}
+	}
+
+	if len(cfg.Cfg.TeamWhiteList) != 0 {
+		for _, orgAndTeam := range cfg.Cfg.TeamWhiteList {
+			org, team := toOrgAndTeam(orgAndTeam)
+			if org != "" {
+				log.Info(org)
+				var (
+					e        error
+					isMember bool
+				)
+				if team != "" {
+					e, isMember = getTeamMembershipStateFromGitHub(client, user, org, team, ptoken)
+				} else {
+					e, isMember = getOrgMembershipStateFromGitHub(client, user, org, ptoken)
+				}
+				if e != nil {
+					return e
+				} else {
+					if isMember {
+						user.TeamMemberships = append(user.TeamMemberships, orgAndTeam)
+					}
+				}
+			} else {
+				log.Warnf("Invalid org/team format in %s: must be written as <orgId>/<teamSlug>", orgAndTeam)
+			}
+		}
+	}
+
+	log.Debug("getUserInfoFromGitHub")
+	log.Debug(user)
+	return nil
+}
+
+func getOrgMembershipStateFromGitHub(client *http.Client, user *structs.User, orgId string, ptoken *oauth2.Token) (rerr error, isMember bool) {
+	replacements := strings.NewReplacer(":org_id", orgId, ":username", user.Username)
+	orgMembershipResp, err := client.Get(replacements.Replace(cfg.GenOAuth.UserOrgURL) + ptoken.AccessToken)
+	if err != nil {
+		log.Error(err)
+		return err, false
+	}
+
+	if orgMembershipResp.StatusCode == 302 {
+		log.Debug("Need to check public membership")
+		location := orgMembershipResp.Header.Get("Location")
+		if location != "" {
+			orgMembershipResp, err = client.Get(location)
+		}
+	}
+
+	if orgMembershipResp.StatusCode == 204 {
+		return nil, true
+	} else if orgMembershipResp.StatusCode == 404 {
+		return nil, false
+	} else {
+		return nil, false
+	}
+}
+
+func getTeamMembershipStateFromGitHub(client *http.Client, user *structs.User, orgId string, team string, ptoken *oauth2.Token) (rerr error, isMember bool) {
+	replacements := strings.NewReplacer(":org_id", orgId, ":team_slug", team, ":username", user.Username)
+	membershipStateResp, err := client.Get(replacements.Replace(cfg.GenOAuth.UserTeamURL) + ptoken.AccessToken)
+	if err != nil {
+		log.Error(err)
+		return err, false
+	}
+	defer func() {
+		if err := membershipStateResp.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	if membershipStateResp.StatusCode == 200 {
+		data, _ := ioutil.ReadAll(membershipStateResp.Body)
+		log.Infof("github team membership body: ", string(data))
+		ghTeamState := structs.GitHubTeamMembershipState{}
+		if err = json.Unmarshal(data, &ghTeamState); err != nil {
+			log.Error(err)
+			return err, false
+		}
+		log.Debug("getTeamMembershipStateFromGitHub ghTeamState")
+		log.Debug(ghTeamState)
+		return nil, ghTeamState.State == "active"
+	} else {
+		return nil, false
+	}
+}

--- a/handlers/github/github_test.go
+++ b/handlers/github/github_test.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/domains"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"golang.org/x/oauth2"
+	"net/http"
+	"regexp"
+
+	mockhttp "github.com/karupanerura/go-mock-http-response"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type ReqMatcher func(*http.Request) bool
+
+type FunResponsePair struct {
+	matcher  ReqMatcher
+	response *mockhttp.ResponseMock
+}
+
+type Transport struct {
+	MockError error
+}
+
+func (c *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if c.MockError != nil {
+		return nil, c.MockError
+	}
+	for _, p := range mockedResponses {
+		if p.matcher(req) {
+			requests = append(requests, req.URL.String())
+			return p.response.MakeResponse(req), nil
+		}
+	}
+	return nil, nil
+}
+
+func mockResponse(fun ReqMatcher, statusCode int, headers map[string]string, body []byte) {
+	mockedResponses = append(mockedResponses, FunResponsePair{matcher: fun, response: mockhttp.NewResponseMock(statusCode, headers, body)})
+}
+
+func regexMatcher(expr string) ReqMatcher {
+	return func(r *http.Request) bool {
+		matches, _ := regexp.Match(expr, []byte(r.URL.String()))
+		return matches
+	}
+}
+
+func urlEquals(value string) ReqMatcher {
+	return func(r *http.Request) bool {
+		return r.URL.String() == value
+	}
+}
+
+func assertUrlCalled(t *testing.T, url string) {
+	found := false
+	for _, requested_url := range requests {
+		if requested_url == url {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "Expected %s to have been called, but got only %s", url, requests)
+}
+
+var (
+	user            *structs.User
+	token           = &oauth2.Token{AccessToken: "123"}
+	mockedResponses = []FunResponsePair{}
+	requests        []string
+	client          = &http.Client{Transport: &Transport{}}
+)
+
+func init() {
+	setUp()
+}
+
+func setUp() {
+	cfg.InitForTestPurposesWithProvider("github")
+
+	cfg.Cfg.AllowAllUsers = false
+	cfg.Cfg.WhiteList = make([]string, 0)
+	cfg.Cfg.TeamWhiteList = make([]string, 0)
+	cfg.Cfg.Domains = []string{"domain1"}
+
+	domains.Refresh()
+
+	mockedResponses = []FunResponsePair{}
+	requests = make([]string, 0)
+
+	user = &structs.User{Username: "testuser", Email: "test@example.com"}
+}
+
+func TestGetTeamMembershipStateFromGitHubActive(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
+
+	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+
+	assert.Nil(t, err)
+	assert.True(t, isMember)
+}
+
+func TestGetTeamMembershipStateFromGitHubInactive(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"inactive\"}"))
+
+	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+
+	assert.Nil(t, err)
+	assert.False(t, isMember)
+}
+
+func TestGetTeamMembershipStateFromGitHubNotAMember(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
+
+	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+
+	assert.Nil(t, err)
+	assert.False(t, isMember)
+}
+
+func TestGetOrgMembershipStateFromGitHubNotFound(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
+
+	err, isMember := getOrgMembershipStateFromGitHub(client, user, "myorg", token)
+
+	assert.Nil(t, err)
+	assert.False(t, isMember)
+
+	expectedOrgMembershipUrl := "https://api.github.com/orgs/myorg/members/" + user.Username + "?access_token=" + token.AccessToken
+	assertUrlCalled(t, expectedOrgMembershipUrl)
+}
+
+func TestGetOrgMembershipStateFromGitHubNoOrgAccess(t *testing.T) {
+	setUp()
+	location := "https://api.github.com/orgs/myorg/public_members/" + user.Username
+
+	mockResponse(regexMatcher(".*orgs/myorg/members.*"), http.StatusFound, map[string]string{"Location": location}, []byte(""))
+	mockResponse(regexMatcher(".*orgs/myorg/public_members.*"), http.StatusNoContent, map[string]string{}, []byte(""))
+
+	err, isMember := getOrgMembershipStateFromGitHub(client, user, "myorg", token)
+
+	assert.Nil(t, err)
+	assert.True(t, isMember)
+
+	expectedOrgMembershipUrl := "https://api.github.com/orgs/myorg/members/" + user.Username + "?access_token=" + token.AccessToken
+	assertUrlCalled(t, expectedOrgMembershipUrl)
+
+	expectedOrgPublicMembershipUrl := "https://api.github.com/orgs/myorg/public_members/" + user.Username
+	assertUrlCalled(t, expectedOrgPublicMembershipUrl)
+}
+
+func TestGetUserInfoFromGitHub(t *testing.T) {
+	setUp()
+
+	userInfoContent, _ := json.Marshal(structs.GitHubUser{
+		User: structs.User{
+			Username:   "test",
+			CreatedOn:  123,
+			Email:      "email@example.com",
+			ID:         1,
+			LastUpdate: 123,
+			Name:       "name",
+		},
+		Login:   "myusername",
+		Picture: "avatar-url",
+	})
+	mockResponse(urlEquals(cfg.GenOAuth.UserInfoURL+token.AccessToken), http.StatusOK, map[string]string{}, userInfoContent)
+
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "myOtherOrg", "myorg/myteam")
+
+	mockResponse(regexMatcher(".*teams.*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
+	mockResponse(regexMatcher(".*members.*"), http.StatusNoContent, map[string]string{}, []byte(""))
+
+	err := GetUserInfoFromGitHub(client, user, &structs.CustomClaims{}, token)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "myusername", user.Username)
+	assert.Equal(t, []string{"myOtherOrg", "myorg/myteam"}, user.TeamMemberships)
+
+	expectedTeamMembershipUrl := "https://api.github.com/orgs/myorg/teams/myteam/memberships/myusername?access_token=" + token.AccessToken
+	assertUrlCalled(t, expectedTeamMembershipUrl)
+}

--- a/handlers/google/google.go
+++ b/handlers/google/google.go
@@ -1,0 +1,39 @@
+package google
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+func GetUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
+	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("google userinfo body: ", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = json.Unmarshal(data, user); err != nil {
+		log.Error(err)
+		return err
+	}
+	user.PrepareUserData()
+
+	return nil
+}

--- a/handlers/google/google.go
+++ b/handlers/google/google.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 )
 
+type Handler struct{}
+
 var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromGoogle(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
 	err, client, _ := common.PrepareTokensAndClient(r, ptokens, true)
 	if err != nil {
 		return err

--- a/handlers/google/google.go
+++ b/handlers/google/google.go
@@ -13,7 +13,11 @@ var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
+func GetUserInfoFromGoogle(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, client, _ := common.PrepareTokensAndClient(r, ptokens, true)
+	if err != nil {
+		return err
+	}
 	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
 	if err != nil {
 		return err

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/vouch/vouch-proxy/handlers/adfs"
 	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/handlers/github"
+	"github.com/vouch/vouch-proxy/handlers/homeassistant"
 	"github.com/vouch/vouch-proxy/handlers/indieauth"
 	"html/template"
 	"io/ioutil"
@@ -543,7 +544,7 @@ func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.Cust
 	}
 	if cfg.GenOAuth.Provider == cfg.Providers.HomeAssistant {
 		ptokens.PAccessToken = providerToken.Extra("access_token").(string)
-		return getUserInfoFromHomeAssistant(r, user, customClaims)
+		return homeassistant.GetUserInfoFromHomeAssistant(r, user, customClaims)
 	}
 	ptokens.PAccessToken = providerToken.AccessToken
 	if cfg.GenOAuth.Provider == cfg.Providers.OpenStax {
@@ -651,13 +652,6 @@ func getUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims
 	}
 	user.PrepareUserData()
 
-	return nil
-}
-
-// More info: https://developers.home-assistant.io/docs/en/auth_api.html
-func getUserInfoFromHomeAssistant(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
-	// Home assistant does not provide an API to query username, so we statically set it to "homeassistant"
-	user.Username = "homeassistant"
 	return nil
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,20 +2,18 @@ package handlers
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/vouch/vouch-proxy/handlers/adfs"
 	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/handlers/github"
 	"github.com/vouch/vouch-proxy/handlers/indieauth"
 	"html/template"
 	"io/ioutil"
 	"net/http"
-	"net/url"
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -537,7 +535,7 @@ func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.Cust
 	if cfg.GenOAuth.Provider == cfg.Providers.IndieAuth {
 		return indieauth.GetUserInfoFromIndieAuth(r, user, customClaims)
 	} else if cfg.GenOAuth.Provider == cfg.Providers.ADFS {
-		return getUserInfoFromADFS(r, user, customClaims, ptokens)
+		return adfs.GetUserInfoFromADFS(r, user, customClaims, ptokens)
 	}
 	providerToken, err := cfg.OAuthClient.Exchange(context.TODO(), r.URL.Query().Get("code"))
 	if err != nil {
@@ -660,97 +658,6 @@ func getUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims
 func getUserInfoFromHomeAssistant(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
 	// Home assistant does not provide an API to query username, so we statically set it to "homeassistant"
 	user.Username = "homeassistant"
-	return nil
-}
-
-type adfsTokenRes struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	IDToken     string `json:"id_token"`
-	ExpiresIn   int64  `json:"expires_in"` // relative seconds from now
-}
-
-// More info: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers#supported-scenarios
-func getUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
-	code := r.URL.Query().Get("code")
-	log.Debugf("code: %s", code)
-
-	formData := url.Values{}
-	formData.Set("code", code)
-	formData.Set("grant_type", "authorization_code")
-	formData.Set("resource", cfg.GenOAuth.RedirectURL)
-	formData.Set("client_id", cfg.GenOAuth.ClientID)
-	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
-	if cfg.GenOAuth.ClientSecret != "" {
-		formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
-	}
-	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
-	if err != nil {
-		return err
-	}
-	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Content-Length", strconv.Itoa(len(formData.Encode())))
-	req.Header.Set("Accept", "application/json")
-
-	client := &http.Client{}
-	userinfo, err := client.Do(req)
-
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := userinfo.Body.Close(); err != nil {
-			rerr = err
-		}
-	}()
-
-	data, _ := ioutil.ReadAll(userinfo.Body)
-	tokenRes := adfsTokenRes{}
-
-	if err := json.Unmarshal(data, &tokenRes); err != nil {
-		log.Errorf("oauth2: cannot fetch token: %v", err)
-		return nil
-	}
-
-	ptokens.PAccessToken = string(tokenRes.AccessToken)
-	ptokens.PIdToken = string(tokenRes.IDToken)
-
-	s := strings.Split(tokenRes.IDToken, ".")
-	if len(s) < 2 {
-		log.Error("jws: invalid token received")
-		return nil
-	}
-
-	idToken, err := base64.RawURLEncoding.DecodeString(s[1])
-	if err != nil {
-		log.Error(err)
-		return nil
-	}
-	log.Debugf("idToken: %+v", string(idToken))
-
-	adfsUser := structs.ADFSUser{}
-	json.Unmarshal([]byte(idToken), &adfsUser)
-	log.Infof("adfs adfsUser: %+v", adfsUser)
-	// data contains an access token, refresh token, and id token
-	// Please note that in order for custom claims to work you MUST set allatclaims in ADFS to be passed
-	// https://oktotechnologies.ca/2018/08/26/adfs-openidconnect-configuration/
-	if err = common.MapClaims([]byte(idToken), customClaims); err != nil {
-		log.Error(err)
-		return err
-	}
-	adfsUser.PrepareUserData()
-	var rxEmail = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-
-	if len(adfsUser.Email) == 0 {
-		// If the email is blank, we will try to determine if the UPN is an email.
-		if rxEmail.MatchString(adfsUser.UPN) {
-			// Set the email from UPN if there is a valid email present.
-			adfsUser.Email = adfsUser.UPN
-		}
-	}
-	user.Username = adfsUser.Username
-	user.Email = adfsUser.Email
-	log.Debugf("User Obj: %+v", user)
 	return nil
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -6,6 +6,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/handlers/github"
 	"html/template"
 	"io/ioutil"
 	"mime/multipart"
@@ -567,7 +569,7 @@ func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.Cust
 	if cfg.GenOAuth.Provider == cfg.Providers.Google {
 		return getUserInfoFromGoogle(client, user, customClaims)
 	} else if cfg.GenOAuth.Provider == cfg.Providers.GitHub {
-		return getUserInfoFromGitHub(client, user, customClaims, providerToken)
+		return github.GetUserInfoFromGitHub(client, user, customClaims, providerToken)
 	} else if cfg.GenOAuth.Provider == cfg.Providers.OIDC {
 		return getUserInfoFromOpenID(client, user, customClaims, providerToken)
 	}
@@ -587,7 +589,7 @@ func getUserInfoFromOpenID(client *http.Client, user *structs.User, customClaims
 	}()
 	data, _ := ioutil.ReadAll(userinfo.Body)
 	log.Infof("OpenID userinfo body: %s", string(data))
-	if err = mapClaims(data, customClaims); err != nil {
+	if err = common.MapClaims(data, customClaims); err != nil {
 		log.Error(err)
 		return err
 	}
@@ -611,7 +613,7 @@ func getUserInfoFromOpenStax(client *http.Client, user *structs.User, customClai
 	}()
 	data, _ := ioutil.ReadAll(userinfo.Body)
 	log.Infof("OpenStax userinfo body: %s", string(data))
-	if err = mapClaims(data, customClaims); err != nil {
+	if err = common.MapClaims(data, customClaims); err != nil {
 		log.Error(err)
 		return err
 	}
@@ -642,7 +644,7 @@ func getUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims
 	}()
 	data, _ := ioutil.ReadAll(userinfo.Body)
 	log.Infof("google userinfo body: %s", string(data))
-	if err = mapClaims(data, customClaims); err != nil {
+	if err = common.MapClaims(data, customClaims); err != nil {
 		log.Error(err)
 		return err
 	}
@@ -653,142 +655,6 @@ func getUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims
 	user.PrepareUserData()
 
 	return nil
-}
-
-// github
-// https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
-func getUserInfoFromGitHub(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
-
-	log.Errorf("ptoken.AccessToken: %s", ptoken.AccessToken)
-	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL + ptoken.AccessToken)
-	if err != nil {
-		// http.Error(w, err.Error(), http.StatusBadRequest)
-		return err
-	}
-	defer func() {
-		if err := userinfo.Body.Close(); err != nil {
-			rerr = err
-		}
-	}()
-	data, _ := ioutil.ReadAll(userinfo.Body)
-	log.Infof("github userinfo body: %s", string(data))
-	if err = mapClaims(data, customClaims); err != nil {
-		log.Error(err)
-		return err
-	}
-	ghUser := structs.GitHubUser{}
-	if err = json.Unmarshal(data, &ghUser); err != nil {
-		log.Error(err)
-		return err
-	}
-	log.Debug("getUserInfoFromGitHub ghUser")
-	log.Debug(ghUser)
-	log.Debug("getUserInfoFromGitHub user")
-	log.Debug(user)
-
-	ghUser.PrepareUserData()
-	user.Email = ghUser.Email
-	user.Name = ghUser.Name
-	user.Username = ghUser.Username
-	user.ID = ghUser.ID
-
-	// user = &ghUser.User
-
-	toOrgAndTeam := func(orgAndTeam string) (string, string) {
-		split := strings.Split(orgAndTeam, "/")
-		if len(split) == 1 {
-			// only organization given
-			return orgAndTeam, ""
-		} else if len(split) == 2 {
-			return split[0], split[1]
-		} else {
-			return "", ""
-		}
-	}
-
-	if len(cfg.Cfg.TeamWhiteList) != 0 {
-		for _, orgAndTeam := range cfg.Cfg.TeamWhiteList {
-			org, team := toOrgAndTeam(orgAndTeam)
-			if org != "" {
-				log.Info(org)
-				var (
-					e        error
-					isMember bool
-				)
-				if team != "" {
-					e, isMember = getTeamMembershipStateFromGitHub(client, user, org, team, ptoken)
-				} else {
-					e, isMember = getOrgMembershipStateFromGitHub(client, user, org, ptoken)
-				}
-				if e != nil {
-					return e
-				} else {
-					if isMember {
-						user.TeamMemberships = append(user.TeamMemberships, orgAndTeam)
-					}
-				}
-			} else {
-				log.Warnf("Invalid org/team format in %s: must be written as <orgId>/<teamSlug>", orgAndTeam)
-			}
-		}
-	}
-
-	log.Debug("getUserInfoFromGitHub")
-	log.Debug(user)
-	return nil
-}
-
-func getOrgMembershipStateFromGitHub(client *http.Client, user *structs.User, orgId string, ptoken *oauth2.Token) (rerr error, isMember bool) {
-	replacements := strings.NewReplacer(":org_id", orgId, ":username", user.Username)
-	orgMembershipResp, err := client.Get(replacements.Replace(cfg.GenOAuth.UserOrgURL) + ptoken.AccessToken)
-	if err != nil {
-		log.Error(err)
-		return err, false
-	}
-
-	if orgMembershipResp.StatusCode == 302 {
-		log.Debug("Need to check public membership")
-		location := orgMembershipResp.Header.Get("Location")
-		if location != "" {
-			orgMembershipResp, err = client.Get(location)
-		}
-	}
-
-	if orgMembershipResp.StatusCode == 204 {
-		return nil, true
-	} else if orgMembershipResp.StatusCode == 404 {
-		return nil, false
-	} else {
-		return nil, false
-	}
-}
-
-func getTeamMembershipStateFromGitHub(client *http.Client, user *structs.User, orgId string, team string, ptoken *oauth2.Token) (rerr error, isMember bool) {
-	replacements := strings.NewReplacer(":org_id", orgId, ":team_slug", team, ":username", user.Username)
-	membershipStateResp, err := client.Get(replacements.Replace(cfg.GenOAuth.UserTeamURL) + ptoken.AccessToken)
-	if err != nil {
-		log.Error(err)
-		return err, false
-	}
-	defer func() {
-		if err := membershipStateResp.Body.Close(); err != nil {
-			rerr = err
-		}
-	}()
-	if membershipStateResp.StatusCode == 200 {
-		data, _ := ioutil.ReadAll(membershipStateResp.Body)
-		log.Infof("github team membership body: ", string(data))
-		ghTeamState := structs.GitHubTeamMembershipState{}
-		if err = json.Unmarshal(data, &ghTeamState); err != nil {
-			log.Error(err)
-			return err, false
-		}
-		log.Debug("getTeamMembershipStateFromGitHub ghTeamState")
-		log.Debug(ghTeamState)
-		return nil, ghTeamState.State == "active"
-	} else {
-		return nil, false
-	}
 }
 
 func getUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
@@ -848,7 +714,7 @@ func getUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims 
 
 	data, _ := ioutil.ReadAll(userinfo.Body)
 	log.Infof("indieauth userinfo body: %s", string(data))
-	if err = mapClaims(data, customClaims); err != nil {
+	if err = common.MapClaims(data, customClaims); err != nil {
 		log.Error(err)
 		return err
 	}
@@ -941,7 +807,7 @@ func getUserInfoFromADFS(r *http.Request, user *structs.User, customClaims *stru
 	// data contains an access token, refresh token, and id token
 	// Please note that in order for custom claims to work you MUST set allatclaims in ADFS to be passed
 	// https://oktotechnologies.ca/2018/08/26/adfs-openidconnect-configuration/
-	if err = mapClaims([]byte(idToken), customClaims); err != nil {
+	if err = common.MapClaims([]byte(idToken), customClaims); err != nil {
 		log.Error(err)
 		return err
 	}
@@ -990,28 +856,4 @@ func ok200(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error(err)
 	}
-}
-
-func mapClaims(claims []byte, customClaims *structs.CustomClaims) error {
-	// Create a struct that contains the claims that we want to store from the config.
-	var f interface{}
-	err := json.Unmarshal(claims, &f)
-	if err != nil {
-		log.Error("Error unmarshaling claims")
-		return err
-	}
-	m := f.(map[string]interface{})
-	for k := range m {
-		var found = false
-		for _, e := range cfg.Cfg.Headers.Claims {
-			if k == e {
-				found = true
-			}
-		}
-		if found == false {
-			delete(m, k)
-		}
-	}
-	customClaims.Claims = m
-	return nil
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -1,16 +1,15 @@
 package handlers
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/handlers/github"
+	"github.com/vouch/vouch-proxy/handlers/indieauth"
 	"html/template"
 	"io/ioutil"
-	"mime/multipart"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -536,7 +535,7 @@ func getUserInfo(r *http.Request, user *structs.User, customClaims *structs.Cust
 
 	// indieauth sends the "me" setting in json back to the callback, so just pluck it from the callback
 	if cfg.GenOAuth.Provider == cfg.Providers.IndieAuth {
-		return getUserInfoFromIndieAuth(r, user, customClaims)
+		return indieauth.GetUserInfoFromIndieAuth(r, user, customClaims)
 	} else if cfg.GenOAuth.Provider == cfg.Providers.ADFS {
 		return getUserInfoFromADFS(r, user, customClaims, ptokens)
 	}
@@ -654,78 +653,6 @@ func getUserInfoFromGoogle(client *http.Client, user *structs.User, customClaims
 	}
 	user.PrepareUserData()
 
-	return nil
-}
-
-func getUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
-
-	code := r.URL.Query().Get("code")
-	log.Errorf("ptoken.AccessToken: %s", code)
-	var b bytes.Buffer
-	w := multipart.NewWriter(&b)
-	// v.Set("code", code)
-	fw, err := w.CreateFormField("code")
-	if err != nil {
-		return err
-	}
-	if _, err = fw.Write([]byte(code)); err != nil {
-		return err
-	}
-	// v.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
-	if fw, err = w.CreateFormField("redirect_uri"); err != nil {
-		return err
-	}
-	if _, err = fw.Write([]byte(cfg.GenOAuth.RedirectURL)); err != nil {
-		return err
-	}
-	// v.Set("client_id", cfg.GenOAuth.ClientID)
-	if fw, err = w.CreateFormField("client_id"); err != nil {
-		return err
-	}
-	if _, err = fw.Write([]byte(cfg.GenOAuth.ClientID)); err != nil {
-		return err
-	}
-	if err = w.Close(); err != nil {
-		log.Error("error closing writer.")
-	}
-
-	req, err := http.NewRequest("POST", cfg.GenOAuth.AuthURL, &b)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", w.FormDataContentType())
-	req.Header.Set("Accept", "application/json")
-
-	// v := url.Values{}
-	// userinfo, err := client.PostForm(cfg.GenOAuth.UserInfoURL, v)
-
-	client := &http.Client{}
-	userinfo, err := client.Do(req)
-
-	if err != nil {
-		// http.Error(w, err.Error(), http.StatusBadRequest)
-		return err
-	}
-	defer func() {
-		if err := userinfo.Body.Close(); err != nil {
-			rerr = err
-		}
-	}()
-
-	data, _ := ioutil.ReadAll(userinfo.Body)
-	log.Infof("indieauth userinfo body: %s", string(data))
-	if err = common.MapClaims(data, customClaims); err != nil {
-		log.Error(err)
-		return err
-	}
-	iaUser := structs.IndieAuthUser{}
-	if err = json.Unmarshal(data, &iaUser); err != nil {
-		log.Error(err)
-		return err
-	}
-	iaUser.PrepareUserData()
-	user.Username = iaUser.Username
-	log.Debug(user)
 	return nil
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -423,6 +423,20 @@ func VerifyUser(u interface{}) (ok bool, err error) {
 		if !ok {
 			err = fmt.Errorf("user.Username not found in WhiteList: %s", user.Username)
 		}
+	} else if len(cfg.Cfg.TeamWhiteList) != 0 && cfg.Cfg.Org != "" {
+		for _, team := range user.TeamMemberships {
+			for _, wl := range cfg.Cfg.TeamWhiteList {
+				if team == wl {
+					log.Debugf("found user.TeamWhiteList in TeamWhiteList: %s for user %s", wl, user.Username)
+					ok = true
+					break
+				}
+			}
+		}
+
+		if !ok {
+			err = fmt.Errorf("user.TeamMemberships %s not found in TeamWhiteList: %s for user %s", user.TeamMemberships, cfg.Cfg.TeamWhiteList, user.Username)
+		}
 	} else if len(cfg.Cfg.Domains) != 0 && !domains.IsUnderManagement(user.Email) {
 		err = fmt.Errorf("Email %s is not within a "+cfg.Branding.CcName+" managed domain", user.Email)
 		// } else if !domains.IsUnderManagement(user.HostDomain) {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,77 +1,17 @@
 package handlers
 
 import (
-	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/domains"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 	"golang.org/x/oauth2"
-	"net/http"
-	"regexp"
-
-	mockhttp "github.com/karupanerura/go-mock-http-response"
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-type ReqMatcher func(*http.Request) bool
-
-type FunResponsePair struct {
-	matcher  ReqMatcher
-	response *mockhttp.ResponseMock
-}
-
-type Transport struct {
-	MockError error
-}
-
-func (c *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if c.MockError != nil {
-		return nil, c.MockError
-	}
-	for _, p := range mockedResponses {
-		if p.matcher(req) {
-			requests = append(requests, req.URL.String())
-			return p.response.MakeResponse(req), nil
-		}
-	}
-	return nil, nil
-}
-
-func mockResponse(fun ReqMatcher, statusCode int, headers map[string]string, body []byte) {
-	mockedResponses = append(mockedResponses, FunResponsePair{matcher: fun, response: mockhttp.NewResponseMock(statusCode, headers, body)})
-}
-
-func regexMatcher(expr string) ReqMatcher {
-	return func(r *http.Request) bool {
-		matches, _ := regexp.Match(expr, []byte(r.URL.String()))
-		return matches
-	}
-}
-
-func urlEquals(value string) ReqMatcher {
-	return func(r *http.Request) bool {
-		return r.URL.String() == value
-	}
-}
-
-func assertUrlCalled(t *testing.T, url string) {
-	found := false
-	for _, requested_url := range requests {
-		if requested_url == url {
-			found = true
-			break
-		}
-	}
-	assert.True(t, found, "Expected %s to have been called, but got only %s", url, requests)
-}
-
 var (
-	user            *structs.User
-	token           = &oauth2.Token{AccessToken: "123"}
-	mockedResponses = []FunResponsePair{}
-	requests        []string
-	client          = &http.Client{Transport: &Transport{}}
+	user  *structs.User
+	token = &oauth2.Token{AccessToken: "123"}
 )
 
 func init() {
@@ -79,7 +19,7 @@ func init() {
 }
 
 func setUp() {
-	cfg.InitForTestPurposesWithProvider("github")
+	cfg.InitForTestPurposes()
 
 	cfg.Cfg.AllowAllUsers = false
 	cfg.Cfg.WhiteList = make([]string, 0)
@@ -87,9 +27,6 @@ func setUp() {
 	cfg.Cfg.Domains = []string{"domain1"}
 
 	domains.Refresh()
-
-	mockedResponses = []FunResponsePair{}
-	requests = make([]string, 0)
 
 	user = &structs.User{Username: "testuser", Email: "test@example.com"}
 }
@@ -159,98 +96,4 @@ func TestVerifyUserNegative(t *testing.T) {
 
 	assert.False(t, ok)
 	assert.NotNil(t, err)
-}
-
-func TestGetTeamMembershipStateFromGitHubActive(t *testing.T) {
-	setUp()
-	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
-
-	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
-
-	assert.Nil(t, err)
-	assert.True(t, isMember)
-}
-
-func TestGetTeamMembershipStateFromGitHubInactive(t *testing.T) {
-	setUp()
-	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"inactive\"}"))
-
-	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
-
-	assert.Nil(t, err)
-	assert.False(t, isMember)
-}
-
-func TestGetTeamMembershipStateFromGitHubNotAMember(t *testing.T) {
-	setUp()
-	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
-
-	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
-
-	assert.Nil(t, err)
-	assert.False(t, isMember)
-}
-
-func TestGetOrgMembershipStateFromGitHubNotFound(t *testing.T) {
-	setUp()
-	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
-
-	err, isMember := getOrgMembershipStateFromGitHub(client, user, "myorg", token)
-
-	assert.Nil(t, err)
-	assert.False(t, isMember)
-
-	expectedOrgMembershipUrl := "https://api.github.com/orgs/myorg/members/" + user.Username + "?access_token=" + token.AccessToken
-	assertUrlCalled(t, expectedOrgMembershipUrl)
-}
-
-func TestGetOrgMembershipStateFromGitHubNoOrgAccess(t *testing.T) {
-	setUp()
-	location := "https://api.github.com/orgs/myorg/public_members/" + user.Username
-
-	mockResponse(regexMatcher(".*orgs/myorg/members.*"), http.StatusFound, map[string]string{"Location": location}, []byte(""))
-	mockResponse(regexMatcher(".*orgs/myorg/public_members.*"), http.StatusNoContent, map[string]string{}, []byte(""))
-
-	err, isMember := getOrgMembershipStateFromGitHub(client, user, "myorg", token)
-
-	assert.Nil(t, err)
-	assert.True(t, isMember)
-
-	expectedOrgMembershipUrl := "https://api.github.com/orgs/myorg/members/" + user.Username + "?access_token=" + token.AccessToken
-	assertUrlCalled(t, expectedOrgMembershipUrl)
-
-	expectedOrgPublicMembershipUrl := "https://api.github.com/orgs/myorg/public_members/" + user.Username
-	assertUrlCalled(t, expectedOrgPublicMembershipUrl)
-}
-
-func TestGetUserInfoFromGitHub(t *testing.T) {
-	setUp()
-
-	userInfoContent, _ := json.Marshal(structs.GitHubUser{
-		User: structs.User{
-			Username:   "test",
-			CreatedOn:  123,
-			Email:      "email@example.com",
-			ID:         1,
-			LastUpdate: 123,
-			Name:       "name",
-		},
-		Login:   "myusername",
-		Picture: "avatar-url",
-	})
-	mockResponse(urlEquals(cfg.GenOAuth.UserInfoURL+token.AccessToken), http.StatusOK, map[string]string{}, userInfoContent)
-
-	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "myOtherOrg", "myorg/myteam")
-
-	mockResponse(regexMatcher(".*teams.*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
-	mockResponse(regexMatcher(".*members.*"), http.StatusNoContent, map[string]string{}, []byte(""))
-
-	err := getUserInfoFromGitHub(client, user, &structs.CustomClaims{}, token)
-
-	assert.Nil(t, err)
-	assert.Equal(t, "myusername", user.Username)
-	assert.Equal(t, []string{"myOtherOrg", "myorg/myteam"}, user.TeamMemberships)
-
-	expectedTeamMembershipUrl := "https://api.github.com/orgs/myorg/teams/myteam/memberships/myusername?access_token=" + token.AccessToken
-	assertUrlCalled(t, expectedTeamMembershipUrl)
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -71,6 +71,8 @@ func setUp() {
 
 	cfg.Cfg.AllowAllUsers = false
 	cfg.Cfg.WhiteList = make([]string, 0)
+	cfg.Cfg.Org = ""
+	cfg.Cfg.TeamWhiteList = make([]string, 0)
 	cfg.Cfg.Domains = []string{"domain1"}
 
 	domains.Refresh()
@@ -106,6 +108,28 @@ func TestVerifyUserPositiveByEmail(t *testing.T) {
 	ok, err := VerifyUser(*user)
 	assert.True(t, ok)
 	assert.Nil(t, err)
+}
+
+func TestVerifyUserPositiveByTeam(t *testing.T) {
+	setUp()
+	cfg.Cfg.Org = "testorg"
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "team2", "team1")
+
+	user.TeamMemberships = append(user.TeamMemberships, "team3")
+	user.TeamMemberships = append(user.TeamMemberships, "team1")
+	ok, err := VerifyUser(*user)
+	assert.True(t, ok)
+	assert.Nil(t, err)
+}
+
+func TestVerifyUserNegativeByTeam(t *testing.T) {
+	setUp()
+	cfg.Cfg.Org = "testorg"
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "team1")
+
+	ok, err := VerifyUser(*user)
+	assert.False(t, ok)
+	assert.NotNil(t, err)
 }
 
 func TestVerifyUserPositiveNoDomainsConfigured(t *testing.T) {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,0 +1,188 @@
+package handlers
+
+import (
+	"encoding/json"
+	"golang.org/x/oauth2"
+	"net/http"
+	"regexp"
+
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/domains"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+
+	mockhttp "github.com/karupanerura/go-mock-http-response"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type ReqMatcher func(*http.Request) bool
+
+type FunResponsePair struct {
+	matcher  ReqMatcher
+	response *mockhttp.ResponseMock
+}
+
+type Transport struct {
+	MockError error
+}
+
+func (c *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if c.MockError != nil {
+		return nil, c.MockError
+	}
+	for _, p := range mockedResponses {
+		if p.matcher(req) {
+			return p.response.MakeResponse(req), nil
+		}
+	}
+	return nil, nil
+}
+
+func mockResponse(fun ReqMatcher, statusCode int, headers map[string]string, body []byte) {
+	mockedResponses = append(mockedResponses, FunResponsePair{matcher: fun, response: mockhttp.NewResponseMock(statusCode, headers, body)})
+}
+
+func regexMatcher(expr string) ReqMatcher {
+	return func(r *http.Request) bool {
+		matches, _ := regexp.Match(expr, []byte(r.URL.String()))
+		return matches
+	}
+}
+
+func urlEquals(value string) ReqMatcher {
+	return func(r *http.Request) bool {
+		return r.URL.String() == value
+	}
+}
+
+var (
+	user            *structs.User
+	token           = &oauth2.Token{AccessToken: "123"}
+	mockedResponses = []FunResponsePair{}
+	client          = &http.Client{Transport: &Transport{}}
+)
+
+func init() {
+	setUp()
+}
+
+func setUp() {
+	cfg.InitForTestPurposesWithProvider("github")
+
+	cfg.Cfg.AllowAllUsers = false
+	cfg.Cfg.WhiteList = make([]string, 0)
+	cfg.Cfg.Domains = []string{"domain1"}
+
+	domains.Refresh()
+
+	mockedResponses = []FunResponsePair{}
+
+	user = &structs.User{Username: "testuser", Email: "test@example.com"}
+}
+
+func TestVerifyUserPositiveUserInWhiteList(t *testing.T) {
+	setUp()
+	cfg.Cfg.WhiteList = append(cfg.Cfg.WhiteList, user.Username)
+
+	ok, err := VerifyUser(*user)
+	assert.True(t, ok)
+	assert.Nil(t, err)
+}
+
+func TestVerifyUserPositiveAllowAllUsers(t *testing.T) {
+	setUp()
+	cfg.Cfg.AllowAllUsers = true
+
+	ok, err := VerifyUser(*user)
+	assert.True(t, ok)
+	assert.Nil(t, err)
+}
+
+func TestVerifyUserPositiveByEmail(t *testing.T) {
+	setUp()
+	cfg.Cfg.Domains = append(cfg.Cfg.Domains, "example.com")
+	domains.Refresh()
+
+	ok, err := VerifyUser(*user)
+	assert.True(t, ok)
+	assert.Nil(t, err)
+}
+
+func TestVerifyUserPositiveNoDomainsConfigured(t *testing.T) {
+	setUp()
+	cfg.Cfg.Domains = make([]string, 0)
+
+	ok, err := VerifyUser(*user)
+
+	assert.True(t, ok)
+	assert.Nil(t, err)
+}
+
+func TestVerifyUserNegative(t *testing.T) {
+	setUp()
+
+	ok, err := VerifyUser(*user)
+
+	assert.False(t, ok)
+	assert.NotNil(t, err)
+}
+
+func TestGetTeamMembershipStateFromGitHubActive(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
+
+	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+
+	assert.Nil(t, err)
+	assert.True(t, isMember)
+}
+
+func TestGetTeamMembershipStateFromGitHubInactive(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"inactive\"}"))
+
+	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+
+	assert.Nil(t, err)
+	assert.False(t, isMember)
+}
+
+func TestGetTeamMembershipStateFromGitHubNotAMember(t *testing.T) {
+	setUp()
+	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
+
+	err, isMember := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+
+	assert.Nil(t, err)
+	assert.False(t, isMember)
+}
+
+func TestGetUserInfoFromGitHub(t *testing.T) {
+	setUp()
+
+	userInfoContent, _ := json.Marshal(structs.GitHubUser{
+		User: structs.User{
+			Username:   "test",
+			CreatedOn:  123,
+			Email:      "email@example.com",
+			ID:         1,
+			LastUpdate: 123,
+			Name:       "name",
+		},
+		Login:   "login",
+		Picture: "avatar-url",
+	})
+	mockResponse(urlEquals(cfg.GenOAuth.UserInfoURL+token.AccessToken), http.StatusOK, map[string]string{}, userInfoContent)
+
+	cfg.Cfg.Org = "myorg"
+
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "myteam")
+
+	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
+
+	err := getUserInfoFromGitHub(client, user, &structs.CustomClaims{}, token)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "login", user.Username)
+	assert.Equal(t, []string{"myteam"}, user.TeamMemberships)
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -71,7 +71,6 @@ func setUp() {
 
 	cfg.Cfg.AllowAllUsers = false
 	cfg.Cfg.WhiteList = make([]string, 0)
-	cfg.Cfg.Org = ""
 	cfg.Cfg.TeamWhiteList = make([]string, 0)
 	cfg.Cfg.Domains = []string{"domain1"}
 
@@ -112,11 +111,10 @@ func TestVerifyUserPositiveByEmail(t *testing.T) {
 
 func TestVerifyUserPositiveByTeam(t *testing.T) {
 	setUp()
-	cfg.Cfg.Org = "testorg"
-	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "team2", "team1")
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "org1/team2", "org1/team1")
 
-	user.TeamMemberships = append(user.TeamMemberships, "team3")
-	user.TeamMemberships = append(user.TeamMemberships, "team1")
+	user.TeamMemberships = append(user.TeamMemberships, "org1/team3")
+	user.TeamMemberships = append(user.TeamMemberships, "org1/team1")
 	ok, err := VerifyUser(*user)
 	assert.True(t, ok)
 	assert.Nil(t, err)
@@ -124,8 +122,7 @@ func TestVerifyUserPositiveByTeam(t *testing.T) {
 
 func TestVerifyUserNegativeByTeam(t *testing.T) {
 	setUp()
-	cfg.Cfg.Org = "testorg"
-	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "team1")
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "org1/team1")
 
 	ok, err := VerifyUser(*user)
 	assert.False(t, ok)
@@ -198,9 +195,7 @@ func TestGetUserInfoFromGitHub(t *testing.T) {
 	})
 	mockResponse(urlEquals(cfg.GenOAuth.UserInfoURL+token.AccessToken), http.StatusOK, map[string]string{}, userInfoContent)
 
-	cfg.Cfg.Org = "myorg"
-
-	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "myteam")
+	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "myorg/myteam")
 
 	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
 
@@ -208,5 +203,5 @@ func TestGetUserInfoFromGitHub(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.Equal(t, "login", user.Username)
-	assert.Equal(t, []string{"myteam"}, user.TeamMemberships)
+	assert.Equal(t, []string{"myorg/myteam"}, user.TeamMemberships)
 }

--- a/handlers/homeassistant/homeassistant.go
+++ b/handlers/homeassistant/homeassistant.go
@@ -1,0 +1,13 @@
+package homeassistant
+
+import (
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"net/http"
+)
+
+// More info: https://developers.home-assistant.io/docs/en/auth_api.html
+func GetUserInfoFromHomeAssistant(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
+	// Home assistant does not provide an API to query username, so we statically set it to "homeassistant"
+	user.Username = "homeassistant"
+	return nil
+}

--- a/handlers/homeassistant/homeassistant.go
+++ b/handlers/homeassistant/homeassistant.go
@@ -1,12 +1,18 @@
 package homeassistant
 
 import (
+	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 	"net/http"
 )
 
 // More info: https://developers.home-assistant.io/docs/en/auth_api.html
-func GetUserInfoFromHomeAssistant(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
+func GetUserInfoFromHomeAssistant(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, _, providerToken := common.PrepareTokensAndClient(r, ptokens, false)
+	if err != nil {
+		return err
+	}
+	ptokens.PAccessToken = providerToken.Extra("access_token").(string)
 	// Home assistant does not provide an API to query username, so we statically set it to "homeassistant"
 	user.Username = "homeassistant"
 	return nil

--- a/handlers/homeassistant/homeassistant.go
+++ b/handlers/homeassistant/homeassistant.go
@@ -6,8 +6,10 @@ import (
 	"net/http"
 )
 
+type Handler struct{}
+
 // More info: https://developers.home-assistant.io/docs/en/auth_api.html
-func GetUserInfoFromHomeAssistant(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
 	err, _, providerToken := common.PrepareTokensAndClient(r, ptokens, false)
 	if err != nil {
 		return err

--- a/handlers/indieauth/indieauth.go
+++ b/handlers/indieauth/indieauth.go
@@ -1,0 +1,88 @@
+package indieauth
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+)
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+func GetUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
+
+	code := r.URL.Query().Get("code")
+	log.Errorf("ptoken.AccessToken: %s", code)
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	// v.Set("code", code)
+	fw, err := w.CreateFormField("code")
+	if err != nil {
+		return err
+	}
+	if _, err = fw.Write([]byte(code)); err != nil {
+		return err
+	}
+	// v.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
+	if fw, err = w.CreateFormField("redirect_uri"); err != nil {
+		return err
+	}
+	if _, err = fw.Write([]byte(cfg.GenOAuth.RedirectURL)); err != nil {
+		return err
+	}
+	// v.Set("client_id", cfg.GenOAuth.ClientID)
+	if fw, err = w.CreateFormField("client_id"); err != nil {
+		return err
+	}
+	if _, err = fw.Write([]byte(cfg.GenOAuth.ClientID)); err != nil {
+		return err
+	}
+	if err = w.Close(); err != nil {
+		log.Error("error closing writer.")
+	}
+
+	req, err := http.NewRequest("POST", cfg.GenOAuth.AuthURL, &b)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Accept", "application/json")
+
+	// v := url.Values{}
+	// userinfo, err := client.PostForm(cfg.GenOAuth.UserInfoURL, v)
+
+	client := &http.Client{}
+	userinfo, err := client.Do(req)
+
+	if err != nil {
+		// http.Error(w, err.Error(), http.StatusBadRequest)
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("indieauth userinfo body: %s", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	iaUser := structs.IndieAuthUser{}
+	if err = json.Unmarshal(data, &iaUser); err != nil {
+		log.Error(err)
+		return err
+	}
+	iaUser.PrepareUserData()
+	user.Username = iaUser.Username
+	log.Debug(user)
+	return nil
+}

--- a/handlers/indieauth/indieauth.go
+++ b/handlers/indieauth/indieauth.go
@@ -11,12 +11,14 @@ import (
 	"net/http"
 )
 
+type Handler struct{}
+
 var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
-
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	// indieauth sends the "me" setting in json back to the callback, so just pluck it from the callback
 	code := r.URL.Query().Get("code")
 	log.Errorf("ptoken.AccessToken: %s", code)
 	var b bytes.Buffer

--- a/handlers/indieauth/indieauth.go
+++ b/handlers/indieauth/indieauth.go
@@ -15,7 +15,7 @@ var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims *structs.CustomClaims) (rerr error) {
+func GetUserInfoFromIndieAuth(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
 
 	code := r.URL.Query().Get("code")
 	log.Errorf("ptoken.AccessToken: %s", code)

--- a/handlers/openid/openid.go
+++ b/handlers/openid/openid.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 )
 
+type Handler struct{}
+
 var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromOpenID(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
 	err, client, _ := common.PrepareTokensAndClient(r, ptokens, true)
 	if err != nil {
 		return err

--- a/handlers/openid/openid.go
+++ b/handlers/openid/openid.go
@@ -5,7 +5,6 @@ import (
 	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
-	"golang.org/x/oauth2"
 	"io/ioutil"
 	"net/http"
 )
@@ -14,7 +13,11 @@ var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromOpenID(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
+func GetUserInfoFromOpenID(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, client, _ := common.PrepareTokensAndClient(r, ptokens, true)
+	if err != nil {
+		return err
+	}
 	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
 	if err != nil {
 		return err

--- a/handlers/openid/openid.go
+++ b/handlers/openid/openid.go
@@ -1,0 +1,39 @@
+package openid
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+func GetUserInfoFromOpenID(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
+	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("OpenID userinfo body: %s", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	if err = json.Unmarshal(data, user); err != nil {
+		log.Error(err)
+		return err
+	}
+	user.PrepareUserData()
+	return nil
+}

--- a/handlers/openstax/openstax.go
+++ b/handlers/openstax/openstax.go
@@ -1,0 +1,46 @@
+package openstax
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"golang.org/x/oauth2"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+func GetUserInfoFromOpenStax(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
+	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("OpenStax userinfo body: %s", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	oxUser := structs.OpenStaxUser{}
+	if err = json.Unmarshal(data, &oxUser); err != nil {
+		log.Error(err)
+		return err
+	}
+
+	oxUser.PrepareUserData()
+	user.Email = oxUser.Email
+	user.Name = oxUser.Name
+	user.Username = oxUser.Username
+	user.ID = oxUser.ID
+	user.PrepareUserData()
+	return nil
+}

--- a/handlers/openstax/openstax.go
+++ b/handlers/openstax/openstax.go
@@ -9,11 +9,13 @@ import (
 	"net/http"
 )
 
+type Handler struct{}
+
 var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromOpenStax(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
 	err, client, _ := common.PrepareTokensAndClient(r, ptokens, false)
 	if err != nil {
 		return err

--- a/handlers/openstax/openstax.go
+++ b/handlers/openstax/openstax.go
@@ -5,7 +5,6 @@ import (
 	"github.com/vouch/vouch-proxy/handlers/common"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
-	"golang.org/x/oauth2"
 	"io/ioutil"
 	"net/http"
 )
@@ -14,7 +13,11 @@ var (
 	log = cfg.Cfg.Logger
 )
 
-func GetUserInfoFromOpenStax(client *http.Client, user *structs.User, customClaims *structs.CustomClaims, ptoken *oauth2.Token) (rerr error) {
+func GetUserInfoFromOpenStax(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, client, _ := common.PrepareTokensAndClient(r, ptokens, false)
+	if err != nil {
+		return err
+	}
 	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
 	if err != nil {
 		return err

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -34,7 +34,6 @@ type config struct {
 	HealthCheck   bool     `mapstructure:"healthCheck"`
 	Domains       []string `mapstructure:"domains"`
 	WhiteList     []string `mapstructure:"whitelist"`
-	Org           string   `mapstructure:"org"`
 	TeamWhiteList []string `mapstructure:"teamWhitelist"`
 	AllowAllUsers bool     `mapstructure:"allowAllUsers"`
 	PublicAccess  bool     `mapstructure:"publicAccess"`

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -87,6 +87,7 @@ type oauthConfig struct {
 	Scopes          []string `mapstructure:"scopes"`
 	UserInfoURL     string   `mapstructure:"user_info_url"`
 	UserTeamURL     string   `mapstructure:"user_team_url"`
+	UserOrgURL      string   `mapstructure:"user_org_url"`
 	PreferredDomain string   `mapstructre:"preferredDomain"`
 }
 
@@ -636,6 +637,9 @@ func setDefaultsGitHub() {
 	}
 	if GenOAuth.UserTeamURL == "" {
 		GenOAuth.UserTeamURL = "https://api.github.com/orgs/:org_id/teams/:team_slug/memberships/:username?access_token="
+	}
+	if GenOAuth.UserOrgURL == "" {
+		GenOAuth.UserOrgURL = "https://api.github.com/orgs/:org_id/members/:username?access_token="
 	}
 	if len(GenOAuth.Scopes) == 0 {
 		// https://github.com/vouch/vouch-proxy/issues/63

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -645,6 +645,10 @@ func setDefaultsGitHub() {
 		// https://github.com/vouch/vouch-proxy/issues/63
 		// https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
 		GenOAuth.Scopes = []string{"read:user"}
+
+		if len(Cfg.TeamWhiteList) > 0 {
+			GenOAuth.Scopes = append(GenOAuth.Scopes, "read:org")
+		}
 	}
 }
 

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -23,3 +23,19 @@ func TestConfigParsing(t *testing.T) {
 	assert.NotEmpty(t, Cfg.JWT.MaxAge)
 
 }
+
+func TestSetGitHubDefaults(t *testing.T) {
+	InitForTestPurposesWithProvider("github")
+
+	assert.Equal(t, []string{"read:user"}, GenOAuth.Scopes)
+}
+
+func TestSetGitHubDefaultsWithTeamWhitelist(t *testing.T) {
+	InitForTestPurposesWithProvider("github")
+	Cfg.TeamWhiteList = append(Cfg.TeamWhiteList, "org/team")
+	GenOAuth.Scopes = []string{}
+
+	setDefaultsGitHub()
+	assert.Contains(t, GenOAuth.Scopes, "read:user")
+	assert.Contains(t, GenOAuth.Scopes, "read:org")
+}

--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -23,8 +23,15 @@ func Refresh() {
 // TODO return all matches
 // Matches return the first match of the
 func Matches(s string) string {
+	if strings.Contains(s, ":") {
+		// then we have a port and we just want to check the host
+		split := strings.Split(s, ":")
+		log.Debugf("removing port from %s to test domain %s", s, split[0])
+		s = split[0]
+	}
+
 	for i, v := range domains {
-		if s == v || strings.HasSuffix(s, "." + v) {
+		if s == v || strings.HasSuffix(s, "."+v) {
 			log.Debugf("domain %s matched array value at [%d]=%v", s, i, v)
 			return v
 		}

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -23,6 +23,8 @@ type User struct {
 	// don't populate ID from json https://github.com/vouch/vouch-proxy/issues/185
 	ID int `json:"-" mapstructure:"id"`
 	// jwt.StandardClaims
+
+	TeamMemberships []string
 }
 
 // PrepareUserData implement PersonalData interface
@@ -77,6 +79,10 @@ type GitHubUser struct {
 	Login   string `json:"login"`
 	Picture string `json:"avatar_url"`
 	// jwt.StandardClaims
+}
+
+type GitHubTeamMembershipState struct {
+	State string `json:"state"`
 }
 
 // PrepareUserData implement PersonalData interface


### PR DESCRIPTION
Allows configuration for GitHub to set whitelist on teams and or organizations when configured like this:
```
vouch:
  teamWhitelist:
   - myOrg
   - myOrg/myTeam
```


As mentioned in #150 this requires additional GitHub API calls to check the membership status.

Also includes the fix for checks of an email against domains: #199.