### PR TITLE
Using vouch.cookie.SameSite configuration option to set SameSite attribute on VouchCookie. Defaults to no SameSite attribute set on VouchCookie

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -67,6 +67,10 @@ vouch:
     httpOnly: true
     # Set cookie maxAge to 0 to delete the cookie every time the browser is closed.
     maxAge: 14400
+    # Set SameSite attribute to restrict browser behaviour when submitting the cookie in a request from a different website.
+    # Valid values 1:{no value}, 2:Lax, 3:Strict, 4:None
+    # If not specified, the cookie will not contain a SameSite attribute value.
+    sameSite: 1
 
   session:
     # name of session variable stored locally

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -47,6 +47,7 @@ type config struct {
 		Secure   bool   `mapstructure:"secure"`
 		HTTPOnly bool   `mapstructure:"httpOnly"`
 		MaxAge   int    `mapstructure:"maxage"`
+		SameSite int    `mapstructure:"sameSite"`
 	}
 
 	Headers struct {

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -31,10 +31,22 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		domain = cfg.Cfg.Cookie.Domain
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
+
 	sameSite := http.SameSiteDefaultMode
-	if cfg.Cfg.Cookie.SameSite != 0 {
-		sameSite = http.SameSite(cfg.Cfg.Cookie.SameSite)
+	if cfg.Cfg.Cookie.SameSite != "" {
+		switch strings.ToLower(cfg.Cfg.Cookie.SameSite) {
+		case "lax":
+			sameSite = http.SameSiteLaxMode
+		case "strict":
+			sameSite = http.SameSiteStrictMode
+		case "none":
+			if cfg.Cfg.Cookie.Secure == false {
+				log.Error("SameSite cookie attribute with sameSite=none should also be specified with secure=true.")
+			}
+			sameSite = http.SameSiteNoneMode
+		}
 	}
+
 	cookie := http.Cookie{
 		Name:     cfg.Cfg.Cookie.Name,
 		Value:    val,

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -32,7 +32,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
 
-	sameSite := http.SameSiteDefaultMode
+	sameSite := http.SameSite(0)
 	if cfg.Cfg.Cookie.SameSite != "" {
 		switch strings.ToLower(cfg.Cfg.Cookie.SameSite) {
 		case "lax":

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -31,6 +31,10 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		domain = cfg.Cfg.Cookie.Domain
 		log.Debugf("setting the cookie domain to %v", domain)
 	}
+	sameSite := http.SameSiteDefaultMode
+	if cfg.Cfg.Cookie.SameSite != 0 {
+		sameSite = http.SameSite(cfg.Cfg.Cookie.SameSite)
+	}
 	cookie := http.Cookie{
 		Name:     cfg.Cfg.Cookie.Name,
 		Value:    val,
@@ -39,6 +43,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 		MaxAge:   maxAge,
 		Secure:   cfg.Cfg.Cookie.Secure,
 		HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+		SameSite: sameSite,
 	}
 	cookieSize := len(cookie.String())
 	cookie.Value = ""
@@ -61,6 +66,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 				MaxAge:   maxAge,
 				Secure:   cfg.Cfg.Cookie.Secure,
 				HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+				SameSite: sameSite,
 			})
 		}
 	} else {
@@ -72,6 +78,7 @@ func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 			MaxAge:   maxAge,
 			Secure:   cfg.Cfg.Cookie.Secure,
 			HttpOnly: cfg.Cfg.Cookie.HTTPOnly,
+			SameSite: sameSite,
 		})
 	}
 }


### PR DESCRIPTION
Depends on https://github.com/vouch/vouch-proxy/pull/213