### PR TITLE
Add nextcloud provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Vouch Proxy supports many OAuth login providers and can enforce authentication t
 - [OAuth2 Server Library for PHP](https://github.com/vouch/vouch-proxy/issues/99)
 - [HomeAssistant](https://developers.home-assistant.io/docs/en/auth_api.html)
 - [OpenStax](https://github.com/vouch/vouch-proxy/pull/141)
+- [Nextcloud](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/oauth2.html)
 - most other OpenID Connect (OIDC) providers
 
 Please do let us know when you have deployed Vouch Proxy with your preffered IdP or library so we can update the list.

--- a/config/config.yml_example_nextcloud
+++ b/config/config.yml_example_nextcloud
@@ -1,0 +1,31 @@
+
+# vouch config
+# bare minimum to get vouch running with Nextcloud Authentication
+
+vouch:
+  # domains:
+  # valid domains that the jwt cookies can be set into
+  # the callback_urls will be to these domains
+  domains:
+  - yourdomain.com
+  - yourotherdomain.com
+
+  # - OR -
+  # instead of setting specific domains you may prefer to allow all users...
+  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
+  # allowAllUsers: true
+
+oauth:
+  # This assumes usage of pretty URLs otherwise add /index.php/
+  # to start of URL path
+  provider: nextcloud
+  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+  auth_url: https://nextcloud.yourdomain.com/apps/oauth2/authorize
+  token_url: https://nextcloud.yourdomain.com/apps/oauth2/api/v1/token
+  user_info_url: https://nextcloud.yourdomain.com/ocs/v2.php/cloud/user?format=json
+  scopes:
+    - openid
+    - email
+    - profile
+  callback_url: http://vouch.yourdomain.com:9090/auth

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vouch/vouch-proxy/handlers/google"
 	"github.com/vouch/vouch-proxy/handlers/homeassistant"
 	"github.com/vouch/vouch-proxy/handlers/indieauth"
+	"github.com/vouch/vouch-proxy/handlers/nextcloud"
 	"github.com/vouch/vouch-proxy/handlers/openid"
 	"github.com/vouch/vouch-proxy/handlers/openstax"
 	"html/template"
@@ -550,6 +551,8 @@ func getHandler() Handler {
 		return google.Handler{}
 	case cfg.Providers.GitHub:
 		return github.Handler{common.PrepareTokensAndClient}
+	case cfg.Providers.Nextcloud:
+		return nextcloud.Handler{}
 	case cfg.Providers.OIDC:
 		return openid.Handler{}
 	default:

--- a/handlers/nextcloud/nextcloud.go
+++ b/handlers/nextcloud/nextcloud.go
@@ -1,0 +1,47 @@
+package nextcloud
+
+import (
+	"encoding/json"
+	"github.com/vouch/vouch-proxy/handlers/common"
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"io/ioutil"
+	"net/http"
+)
+
+type Handler struct{}
+
+var (
+	log = cfg.Cfg.Logger
+)
+
+func (Handler) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens) (rerr error) {
+	err, client, _ := common.PrepareTokensAndClient(r, ptokens, true)
+	if err != nil {
+		return err
+	}
+	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("Ocs userinfo body: %s", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	ncUser := structs.NextcloudUser{}
+	if err = json.Unmarshal(data, &ncUser); err != nil {
+		log.Error(err)
+		return err
+	}
+	ncUser.PrepareUserData()
+	user.Username = ncUser.Username
+	user.Email = ncUser.Email
+	return nil
+}

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -100,6 +100,7 @@ type OAuthProviders struct {
 	OIDC          string
 	HomeAssistant string
 	OpenStax      string
+	Nextcloud     string
 }
 
 type branding struct {
@@ -137,6 +138,7 @@ var (
 		OIDC:          "oidc",
 		HomeAssistant: "homeassistant",
 		OpenStax:      "openstax",
+		Nextcloud:     "nextcloud",
 	}
 
 	// RequiredOptions must have these fields set for minimum viable config
@@ -370,7 +372,8 @@ func BasicTest() error {
 		GenOAuth.Provider != Providers.HomeAssistant &&
 		GenOAuth.Provider != Providers.ADFS &&
 		GenOAuth.Provider != Providers.OIDC &&
-		GenOAuth.Provider != Providers.OpenStax {
+		GenOAuth.Provider != Providers.OpenStax &&
+		GenOAuth.Provider != Providers.Nextcloud {
 		return errors.New("configuration error: Unkown oauth provider: " + GenOAuth.Provider)
 	}
 
@@ -594,7 +597,7 @@ func setProviderDefaults() {
 		setDefaultsADFS()
 		configureOAuthClient()
 	} else {
-		// IndieAuth, OIDC, OpenStax
+		// IndieAuth, OIDC, OpenStax, Nextcloud
 		configureOAuthClient()
 	}
 }

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -128,6 +128,27 @@ func (u *OpenStaxUser) PrepareUserData() {
 	}
 }
 
+// Ocs used for NextcloudUser
+type Ocs struct {
+	Data struct {
+		UserId string `json:"id"`
+		Email  string `json:"email"`
+	} `json:"data"`
+}
+
+// User of Nextcloud retreived from ocs endpoint
+type NextcloudUser struct {
+	User
+	Ocs Ocs `json:"ocs"`
+}
+
+func (u *NextcloudUser) PrepareUserData() {
+	if u.Username == "" {
+		u.Username = u.Ocs.Data.UserId
+		u.Email = u.Ocs.Data.Email
+	}
+}
+
 // Team has members and provides acess to sites
 type Team struct {
 	Name       string   `json:"name" mapstructure:"name"`


### PR DESCRIPTION
Nextcloud provides an OAuth2 API to leverage the built in user management (see [here](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/oauth2.html)). Problem is, they don't provide a proper oauth user endpoint, but it is possible to use the ocs API instead (see [here](https://docs.nextcloud.com/server/latest/developer_manual/client_apis/OCS/ocs-api-overview.html?highlight=ocs#user-metadata)) in json mode.

This needs dedicated handling to extract the proper user info as with other providers. Therefore I added it as an additional provider. I also added an example config with the usual paths of the the auth, token and user urls.