### PR TITLE
Github workflow for arm v7 and arm64 docker image

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       -
         name: Set up Docker Buildx
         id: buildx
@@ -25,6 +25,7 @@ jobs:
         run: echo ${{ steps.buildx.outputs.platforms }}
       -
         name: Docker login (set DOCKER_USERNAME and DOCKER_PASSWORD in secrets)
+        if:  ${{ success() && startsWith(github.repository, 'vouch/')}} # Remove this line, if you want everybody to publish to docker hub
         run:
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
       -
@@ -34,15 +35,15 @@ jobs:
           docker buildx build \
             --platform linux/arm/v7,linux/arm64 \
             --push \
-            -f ./.build/Dockerfile \
             -t voucher/vouch-proxy:$DOCKER_TAG \
             .
-      -
-        name: Publish to docker as github_user/github_repo
-        if: ${{ success() && !startsWith(github.repository, 'vouch/')}}
-        run: |
-          docker buildx build \
-            --platform linux/amd64,linux/arm/v7,linux/arm64 \
-            --push \
-            -t $GITHUB_REPOSITORY:latest \
-            .
+    # Uncomment below to have github build to docker for every user. Watch out for indentation
+    #   -
+    #     name: Publish to docker as github_user/github_repo
+    #     if: ${{ success() && !startsWith(github.repository, 'vouch/')}}
+    #     run: |
+    #       docker buildx build \
+    #         --platform linux/amd64,linux/arm/v7,linux/arm64 \
+    #         --push \
+    #         -t $GITHUB_REPOSITORY:latest \
+    #         .

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -44,6 +44,5 @@ jobs:
           docker buildx build \
             --platform linux/amd64,linux/arm/v7,linux/arm64 \
             --push \
-            -f ./.build/Dockerfile \
             -t $GITHUB_REPOSITORY:latest \
             .

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,49 @@
+name: Docker build and push
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Publish-to-docker:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: latest-multi
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v1
+      -
+        name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v1
+        with:
+          version: latest
+      -
+        name: List available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      -
+        name: Docker login (set DOCKER_USERNAME and DOCKER_PASSWORD in secrets)
+        run:
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Publish to docker as voucher/vouch-proxy
+        if:  ${{ success() && startsWith(github.repository, 'vouch/')}}
+        run: |
+          docker buildx build \
+            --platform linux/arm/v7,linux/arm64 \
+            --push \
+            -f ./.build/Dockerfile \
+            -t voucher/vouch-proxy:$DOCKER_TAG \
+            .
+      -
+        name: Publish to docker as github_user/github_repo
+        if: ${{ success() && !startsWith(github.repository, 'vouch/')}}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 \
+            --push \
+            -f ./.build/Dockerfile \
+            -t $GITHUB_REPOSITORY:latest \
+            .


### PR DESCRIPTION
Fixes #178 

This workflow will build on every push to master. It will create a new docker image tagged `voucher/vouch-proxy:latest-multi`, for this to work you'll need to set the `DOCKER_USERNAME` and `DOCKER_PASSWORD` in https://github.com/vouch/vouch-proxy/settings/secrets

The username is your regular docker username and the password can be your password or a special token from the docker hub.

The new tag only supports **arm/v7** and **arm64**, it's set to not support amd64 so the regular image workflow should still work and only people  looking for an arm image will get these images.