### PR TITLE
fix: examples/nginx/single-file server blocks in http block

### DIFF
--- a/examples/nginx/single-file/nginx_basic.conf
+++ b/examples/nginx/single-file/nginx_basic.conf
@@ -23,65 +23,67 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-}
 
-server {
-    listen 443 ssl http2;
-    server_name protectedapp.yourdomain.com;
-    root /var/www/html/;
 
-    ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
+    server {
+        listen 443 ssl http2;
+        server_name protectedapp.yourdomain.com;
+        root /var/www/html/;
 
-    # send all requests to the `/validate` endpoint for authorization
-    auth_request /validate;
+        ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
 
-    location = /validate {
-      # forward the /validate request to Vouch Proxy
-      proxy_pass http://vouch.yourdomain.com:9090/validate;
+        # send all requests to the `/validate` endpoint for authorization
+        auth_request /validate;
 
-      # be sure to pass the original host header
-      proxy_set_header Host $http_host;
+        location = /validate {
+          # forward the /validate request to Vouch Proxy
+          proxy_pass http://vouch.yourdomain.com:9090/validate;
 
-      # Vouch Proxy only acts on the request headers
-      proxy_pass_request_body off;
-      proxy_set_header Content-Length "";
+          # be sure to pass the original host header
+          proxy_set_header Host $http_host;
 
-      # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
-      auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+          # Vouch Proxy only acts on the request headers
+          proxy_pass_request_body off;
+          proxy_set_header Content-Length "";
 
-      # these return values are used by the @error401 call
-      auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
-      auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
-      auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+          # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
+          auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+
+          # these return values are used by the @error401 call
+          auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+          auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+          auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+        }
+
+        # if validate returns `401 not authorized` then forward the request to the error401block
+        error_page 401 = @error401;
+
+        location @error401 {
+            # redirect to Vouch Proxy for login
+            return 302 http://vouch.yourdomain.com:9090/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+            # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
+            # but to get started you can just forward the end user to the port that vouch is running on
+        }
+
+        # proxy pass authorized requests to your service
+        location / {
+          # forward authorized requests to your service protectedapp.yourdomain.com
+          proxy_pass http://127.0.0.1:8080;
+          # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+          #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
+          #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+          #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+
+          # set user header (usually an email)
+          proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
+          # optionally pass any custom claims you are tracking
+          #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+          #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+          # optionally pass the accesstoken or idtoken
+          #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
+          #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
+        }
     }
 
-    # if validate returns `401 not authorized` then forward the request to the error401block
-    error_page 401 = @error401;
-
-    location @error401 {
-        # redirect to Vouch Proxy for login
-        return 302 http://vouch.yourdomain.com:9090/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
-        # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
-        # but to get started you can just forward the end user to the port that vouch is running on
-    }
-
-    # proxy pass authorized requests to your service
-    location / {
-      # forward authorized requests to your service protectedapp.yourdomain.com
-      proxy_pass http://127.0.0.1:8080;
-      # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
-      #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
-
-      # set user header (usually an email)
-      proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
-      # optionally pass any custom claims you are tracking
-      #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
-      #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
-      # optionally pass the accesstoken or idtoken
-      #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
-      #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
-    }
 }

--- a/examples/nginx/single-file/nginx_with_vouch.conf
+++ b/examples/nginx/single-file/nginx_with_vouch.conf
@@ -23,75 +23,76 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-}
 
-server {
-    listen 443 ssl http2;
-    server_name protectedapp.yourdomain.com;
-    root /var/www/html/;
+    server {
+        listen 443 ssl http2;
+        server_name protectedapp.yourdomain.com;
+        root /var/www/html/;
 
-    ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
+        ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
 
-    # send all requests to the `/validate` endpoint for authorization
-    auth_request /validate;
+        # send all requests to the `/validate` endpoint for authorization
+        auth_request /validate;
 
-    location = /validate {
-      # forward the /validate request to Vouch Proxy
-      proxy_pass http://127.0.0.1:9090/validate;
+        location = /validate {
+        # forward the /validate request to Vouch Proxy
+        proxy_pass http://127.0.0.1:9090/validate;
 
-      # be sure to pass the original host header
-      proxy_set_header Host $http_host;
+        # be sure to pass the original host header
+        proxy_set_header Host $http_host;
 
-      # Vouch Proxy only acts on the request headers
-      proxy_pass_request_body off;
-      proxy_set_header Content-Length "";
+        # Vouch Proxy only acts on the request headers
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
 
-      # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
-      auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+        # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
+        auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
 
-      # these return values are used by the @error401 call
-      auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
-      auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
-      auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+        # these return values are used by the @error401 call
+        auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+        auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+        auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+        }
+
+        # if validate returns `401 not authorized` then forward the request to the error401block
+        error_page 401 = @error401;
+
+        location @error401 {
+            # redirect to Vouch Proxy for login
+            return 302 http://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+            # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
+            # but to get started you can just forward the end user to the port that vouch is running on
+        }
+
+        # proxy pass authorized requests to your service
+        location / {
+        # forward authorized requests to your service protectedapp.yourdomain.com
+        proxy_pass http://127.0.0.1:8080;
+        # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+        #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
+        #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+        #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+
+        # set user header (usually an email)
+        proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
+        # optionally pass any custom claims you are tracking
+        #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+        #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+        # optionally pass the accesstoken or idtoken
+        #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
+        #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
+        }
     }
 
-    # if validate returns `401 not authorized` then forward the request to the error401block
-    error_page 401 = @error401;
-
-    location @error401 {
-        # redirect to Vouch Proxy for login
-        return 302 http://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
-        # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
-        # but to get started you can just forward the end user to the port that vouch is running on
+    server {
+        listen 80 default_server;
+        server_name vouch.yourdomain.com;
+        location / {
+        proxy_pass http://127.0.0.1:9090;
+        # be sure to pass the original host header
+        proxy_set_header Host vouch.yourdomain.com;
+        }
     }
 
-    # proxy pass authorized requests to your service
-    location / {
-      # forward authorized requests to your service protectedapp.yourdomain.com
-      proxy_pass http://127.0.0.1:8080;
-      # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
-      #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
-
-      # set user header (usually an email)
-      proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
-      # optionally pass any custom claims you are tracking
-      #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
-      #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
-      # optionally pass the accesstoken or idtoken
-      #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
-      #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
-    }
-}
-
-server {
-    listen 80 default_server;
-    server_name vouch.yourdomain.com;
-    location / {
-       proxy_pass http://127.0.0.1:9090;
-       # be sure to pass the original host header
-       proxy_set_header Host vouch.yourdomain.com;
-    }
 }

--- a/examples/nginx/single-file/nginx_with_vouch_single_server.conf
+++ b/examples/nginx/single-file/nginx_with_vouch_single_server.conf
@@ -23,75 +23,77 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-}
-upstream vouch {
-    # set this to location of the vouch proxy
-    server localhost:9090;
-}
-server {
-    listen 443 ssl http2;
-    server_name protectedapp.yourdomain.com;
-    root /var/www/html/;
 
-    ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
-
-    # This location serves all of the paths vouch uses
-    location ~ /(auth|login|logout|static) {
-      proxy_pass http://vouch;
-      proxy_set_header Host $http_host;
+    upstream vouch {
+        # set this to location of the vouch proxy
+        server localhost:9090;
     }
 
+    server {
+        listen 443 ssl http2;
+        server_name protectedapp.yourdomain.com;
+        root /var/www/html/;
 
-    location = /validate {
-      # forward the /validate request to Vouch Proxy
-      proxy_pass http://vouch/validate;
+        ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
 
-      # be sure to pass the original host header
-      proxy_set_header Host $http_host;
+        # This location serves all of the paths vouch uses
+        location ~ /(auth|login|logout|static) {
+          proxy_pass http://vouch;
+          proxy_set_header Host $http_host;
+        }
 
-      # Vouch Proxy only acts on the request headers
-      proxy_pass_request_body off;
-      proxy_set_header Content-Length "";
+        location = /validate {
+          # forward the /validate request to Vouch Proxy
+          proxy_pass http://vouch/validate;
 
-      # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
-      auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+          # be sure to pass the original host header
+          proxy_set_header Host $http_host;
 
-      # these return values are used by the @error401 call
-      auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
-      auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
-      auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+          # Vouch Proxy only acts on the request headers
+          proxy_pass_request_body off;
+          proxy_set_header Content-Length "";
+
+          # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
+          auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+
+          # these return values are used by the @error401 call
+          auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+          auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+          auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+        }
+
+        # if validate returns `401 not authorized` then forward the request to the error401block
+        error_page 401 = @error401;
+
+        location @error401 {
+            # redirect to Vouch Proxy for login
+            return 302 http://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+            # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
+            # but to get started you can just forward the end user to the port that vouch is running on
+        }
+
+        # proxy pass authorized requests to your service
+        location / {
+          # send all requests to the `/validate` endpoint for authorization
+          auth_request /validate;
+
+          # forward authorized requests to your service protectedapp.yourdomain.com
+          proxy_pass http://127.0.0.1:8080;
+          # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+          #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
+          #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+          #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+
+          # set user header (usually an email)
+          proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
+          # optionally pass any custom claims you are tracking
+          #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+          #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+          # optionally pass the accesstoken or idtoken
+          #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
+          #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
+        }
     }
 
-    # if validate returns `401 not authorized` then forward the request to the error401block
-    error_page 401 = @error401;
-
-    location @error401 {
-        # redirect to Vouch Proxy for login
-        return 302 http://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
-        # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
-        # but to get started you can just forward the end user to the port that vouch is running on
-    }
-
-    # proxy pass authorized requests to your service
-    location / {
-      # send all requests to the `/validate` endpoint for authorization
-      auth_request /validate;
-
-      # forward authorized requests to your service protectedapp.yourdomain.com
-      proxy_pass http://127.0.0.1:8080;
-      # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
-      #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
-
-      # set user header (usually an email)
-      proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
-      # optionally pass any custom claims you are tracking
-      #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
-      #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
-      # optionally pass the accesstoken or idtoken
-      #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
-      #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
-    }
 }

--- a/examples/nginx/single-file/nginx_with_vouch_ssl.conf
+++ b/examples/nginx/single-file/nginx_with_vouch_ssl.conf
@@ -23,78 +23,80 @@ http {
     #tcp_nopush     on;
 
     keepalive_timeout  65;
-}
 
-server {
-    listen 443 ssl http2;
-    server_name protectedapp.yourdomain.com;
-    root /var/www/html/;
 
-    ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
+    server {
+        listen 443 ssl http2;
+        server_name protectedapp.yourdomain.com;
+        root /var/www/html/;
 
-    # send all requests to the `/validate` endpoint for authorization
-    auth_request /validate;
+        ssl_certificate /etc/letsencrypt/live/protectedapp.yourdomain.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
 
-    location = /validate {
-      # forward the /validate request to Vouch Proxy
-      proxy_pass http://127.0.0.1:9090/validate;
+        # send all requests to the `/validate` endpoint for authorization
+        auth_request /validate;
 
-      # be sure to pass the original host header
-      proxy_set_header Host $http_host;
+        location = /validate {
+        # forward the /validate request to Vouch Proxy
+        proxy_pass http://127.0.0.1:9090/validate;
 
-      # Vouch Proxy only acts on the request headers
-      proxy_pass_request_body off;
-      proxy_set_header Content-Length "";
+        # be sure to pass the original host header
+        proxy_set_header Host $http_host;
 
-      # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
-      auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+        # Vouch Proxy only acts on the request headers
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
 
-      # these return values are used by the @error401 call
-      auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
-      auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
-      auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+        # optionally add X-Vouch-User as returned by Vouch Proxy along with the request
+        auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user;
+
+        # these return values are used by the @error401 call
+        auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+        auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+        auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+        }
+
+        # if validate returns `401 not authorized` then forward the request to the error401block
+        error_page 401 = @error401;
+
+        location @error401 {
+            # redirect to Vouch Proxy for login
+            return 302 https://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+        }
+
+        # proxy pass authorized requests to your service
+        location / {
+        # forward authorized requests to your service protectedapp.yourdomain.com
+        proxy_pass http://127.0.0.1:8080;
+        # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
+        #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
+        #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
+        #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
+
+        # set user header (usually an email)
+        proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
+        # optionally pass any custom claims you are tracking
+        #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
+        #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
+        # optionally pass the accesstoken or idtoken
+        #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
+        #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
+        }
     }
 
-    # if validate returns `401 not authorized` then forward the request to the error401block
-    error_page 401 = @error401;
+    server {
+        # Setting vouch behind SSL allows you to use the Secure flag for cookies.
+        listen 443 ssl http2;
+        server_name vouch.yourdomain.com;
 
-    location @error401 {
-        # redirect to Vouch Proxy for login
-        return 302 https://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+        ssl_certificate /etc/letsencrypt/live/vouch.yourdomain.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/vouch.yourdomain.com/privkey.pem;
+
+        location / {
+        proxy_pass http://127.0.0.1:9090;
+        # be sure to pass the original host header
+        proxy_set_header Host vouch.yourdomain.com;
+        }
     }
 
-    # proxy pass authorized requests to your service
-    location / {
-      # forward authorized requests to your service protectedapp.yourdomain.com
-      proxy_pass http://127.0.0.1:8080;
-      # you may need to set these variables in this block as per https://github.com/vouch/vouch-proxy/issues/26#issuecomment-425215810
-      #    auth_request_set $auth_resp_x_vouch_user $upstream_http_x_vouch_user
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_groups $upstream_http_x_vouch_idp_claims_groups;
-      #    auth_request_set $auth_resp_x_vouch_idp_claims_given_name $upstream_http_x_vouch_idp_claims_given_name;
-
-      # set user header (usually an email)
-      proxy_set_header X-Vouch-User $auth_resp_x_vouch_user;
-      # optionally pass any custom claims you are tracking
-      #     proxy_set_header X-Vouch-IdP-Claims-Groups $auth_resp_x_vouch_idp_claims_groups;
-      #     proxy_set_header X-Vouch-IdP-Claims-Given_Name $auth_resp_x_vouch_idp_claims_given_name;
-      # optionally pass the accesstoken or idtoken
-      #     proxy_set_header X-Vouch-IdP-AccessToken $auth_resp_x_vouch_idp_accesstoken;
-      #     proxy_set_header X-Vouch-IdP-IdToken $auth_resp_x_vouch_idp_idtoken;
-    }
-}
-
-server {
-    # Setting vouch behind SSL allows you to use the Secure flag for cookies.
-    listen 443 ssl http2;
-    server_name vouch.yourdomain.com;
-
-    ssl_certificate /etc/letsencrypt/live/vouch.yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/vouch.yourdomain.com/privkey.pem;
-
-    location / {
-       proxy_pass http://127.0.0.1:9090;
-       # be sure to pass the original host header
-       proxy_set_header Host vouch.yourdomain.com;
-    }
 }


### PR DESCRIPTION
fixes #260

Just formatting changes to move the nginx conf `server` block(s) inside the `http` block. 