### PR TITLE
fix: use relative URL for 302 redirect [skip ci]

### DIFF
--- a/examples/nginx/single-file/nginx_with_vouch_single_server.conf
+++ b/examples/nginx/single-file/nginx_with_vouch_single_server.conf
@@ -68,7 +68,7 @@ http {
 
         location @error401 {
             # redirect to Vouch Proxy for login
-            return 302 http://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+            return 302 login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
             # you usually *want* to redirect to Vouch running behind the same Nginx config proteced by https
             # but to get started you can just forward the end user to the port that vouch is running on
         }


### PR DESCRIPTION
Small tweak for the nginx+vouch single server example:
- use a relative URL for the redirect to vouch's login page