### PR TITLE
Issue 274 - log copy of Cfg with masked secrets

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -194,7 +194,15 @@ func configureFromEnv() bool {
 	if !reflect.DeepEqual(preEnvConfig, *Cfg) ||
 		!reflect.DeepEqual(preEnvGenOAuth, *GenOAuth) {
 		log.Debugf("preEnvConfig %+v", preEnvConfig)
-		log.Debugf("Cfg %+v", Cfg)
+		// Mask sensitive configuration items before logging
+		maskedCfg := *Cfg
+		if len(Cfg.Session.Key) != 0 {
+			maskedCfg.Session.Key = "XXXXXXXX"
+		}
+		if len(Cfg.JWT.Secret) != 0 {
+			maskedCfg.JWT.Secret = "XXXXXXXX"
+		}
+		log.Debugf("Cfg %+v", maskedCfg)
 		log.Infof("%s configuration set from Environmental Variables", Branding.FullName)
 		return true
 	}


### PR DESCRIPTION
With reference to https://github.com/vouch/vouch-proxy/issues/274, when logging the configuration derived from environment variables, mask the values of `Session.Key` and `JWT.Secret` by creating a copy of `Cfg`, replacing those values with `XXXXXXXX` and logging the copy.

Two examples of the log output, the first where the two secrets are specified in the environment and the second where they are not, can be seen here:

https://hasteb.in/ditorunu.json
