### PR TITLE
Add vouch.cookie.domain description to allowAllUsers configuration.

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -34,7 +34,7 @@ vouch:
 
   # Set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider - VOUCH_ALLOWALLUSERS
   # allowAllUsers: false
-  # Set vouch.cookie.domain in the below instead of vouch.domains when enabling allowAllUsers.
+  # vouch.cookie.domain must be set below when enabling allowAllUsers
 
   # Setting publicAccess: true will accept all requests, even without a cookie.  - VOUCH_PUBLICACCESS
   # If the user is logged in, the cookie will be validated and the user header will be set.

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -34,6 +34,7 @@ vouch:
 
   # Set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider - VOUCH_ALLOWALLUSERS
   # allowAllUsers: false
+  # Set vouch.cookie.domain in the below instead of vouch.domains when enabling allowAllUsers.
 
   # Setting publicAccess: true will accept all requests, even without a cookie.  - VOUCH_PUBLICACCESS
   # If the user is logged in, the cookie will be validated and the user header will be set.

--- a/config/config.yml_example_oidc
+++ b/config/config.yml_example_oidc
@@ -13,7 +13,10 @@ vouch:
   # - OR -
   # instead of setting specific domains you may prefer to allow all users...
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
+  # and vouch.cookie.domain to your callback_url domain.
   # allowAllUsers: true
+  # cookie:
+  #   domain: yourdomain.com
 
 oauth:
   # Generic OpenID Connect

--- a/config/config.yml_example_oidc
+++ b/config/config.yml_example_oidc
@@ -13,7 +13,7 @@ vouch:
   # - OR -
   # instead of setting specific domains you may prefer to allow all users...
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
-  # and vouch.cookie.domain to your callback_url domain.
+  # and set vouch.cookie.domain to the domain you wish to protect
   # allowAllUsers: true
   # cookie:
   #   domain: yourdomain.com


### PR DESCRIPTION
Related to #266 

Adding the description of vouch.cookie.domain for 'allowAllUsers: true' config.

This PR is only for the following 2 config examples that directly relate to the issue #266 

The configuration test and results are available [here on the gist](https://gist.github.com/yaws-k/9e81d8f492176fd72683edd1d577e637)

- config/config.yml_example_oidc
- config/config.yml_example

**config/config.yml_example_oidc**

To use `allowAllUsers: true`, `vouch.cookie.domain` is required instead of `vouch.domains`. The descriptions about this and actual `vouch.cookie.domain` config is added to the example.

**config/config.yml_example**

At least in the case with oidc (Okta), setting both `allowAllUsers: true` and `vouch.domains` are not allowed. For the case with `allowAllUsers: true`, the description of `vouch.cookie.domain` is added as a reminder.

There are several config examples with `allowAllUsers: true` that may need to be reviewed.

- config.yml_example_adfs
- config.yml_example_gitea
- config.yml_example_github
- config.yml_example_github_enterprise
- config.yml_example_homeassistant
- config.yml_example_indieauth
- config.yml_example_nextcloud

They are excluded from this PR because of some other issues (e.g. the example fails when starting vouch-proxy) and the lack of testing environment.