### PR TITLE
Less aggressive url param parsing

### DIFF
--- a/handlers/login.go
+++ b/handlers/login.go
@@ -134,7 +134,8 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, []string, error) {
 		lcParamKey := strings.ToLower(paramKey)
 		isVouchParam := strings.HasPrefix(lcParamKey, cfg.Branding.LCName) ||
 			strings.HasPrefix(lcParamKey, "x-"+cfg.Branding.LCName) ||
-			paramKey == "error"
+			paramKey == "error" || // Used by VouchProxy login
+			paramKey == "rd" // Passed to VouchProxy by nginx-ingress and then ignored (see #289)
 
 		if urlParam == nil {
 			// Still looking for url param

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -156,11 +156,11 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 				} else {
 					urlParam.RawQuery = urlParam.RawQuery + "&" + param
 				}
-			} else {
+			} else if !isVouchParam {
 				// Non-vouch param after vouch param is a stray param
 				log.Infof("Stray param in login request (%s)", paramKey)
 				strayParams = true
-			}
+			} // else vouch param after vouch param, doesn't change outcome
 		}
 	}
 

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -108,6 +108,7 @@ var (
 // -- here param and param2 -- belong to the url param of login)
 // The algorithm is as follows:
 // * All login params starting with vouch- or x-vouch- (case insensitively) are treated as true login params
+// * The "error" login param (case sensitively) is treated as true login param
 // * All other login params are treated as non-login params
 // * All non-login params between the url param and the first true login param are folded into the url param
 // * All remaining non-login params are considered stray non-login params
@@ -125,7 +126,7 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 		paramKeyVal := strings.Split(param, "=")
 		paramKey := paramKeyVal[0]
 		lcParamKey := strings.ToLower(paramKey)
-		isVouchParam := strings.HasPrefix(lcParamKey, "vouch-") || strings.HasPrefix(lcParamKey, "x-vouch-")
+		isVouchParam := strings.HasPrefix(lcParamKey, "vouch-") || strings.HasPrefix(lcParamKey, "x-vouch-") || paramKey == "error"
 
 		if urlParam == nil {
 			// Still looking for url param

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -134,8 +134,7 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, []string, error) {
 		lcParamKey := strings.ToLower(paramKey)
 		isVouchParam := strings.HasPrefix(lcParamKey, cfg.Branding.LCName) ||
 			strings.HasPrefix(lcParamKey, "x-"+cfg.Branding.LCName) ||
-			paramKey == "error" ||
-			paramKey == "rd"
+			paramKey == "error"
 
 		if urlParam == nil {
 			// Still looking for url param

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -98,7 +98,6 @@ var (
 	errNoURL            = errors.New("no destination URL requested")
 	errInvalidURL       = errors.New("requested destination URL appears to be invalid")
 	errURLNotHTTP       = errors.New("requested destination URL is not a valid URL (does not begin with 'http://' or 'https://')")
-	errLoginStrayParams = errors.New("login request included unrecognized parameters")
 	errDangerQS         = errors.New("requested destination URL has a dangerous query string")
 	badStrings          = []string{"http://", "https://", "data:", "ftp://", "ftps://", "//", "javascript:"}
 	reAmpSemi           = regexp.MustCompile("[&;]")
@@ -117,15 +116,17 @@ var (
 // * All other login params are treated as non-login params
 // * All non-login params between the url param and the first true login param are folded into the url param
 // * All remaining non-login params are considered stray non-login params
-// * Error is returned if the url cannot be parsed *or* it contains stray non-login params
-// * For the benefit of unit-testing, if the url contains stray non-login params, it's
-// returned anyway (in addition to error return)
-func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
+// 
+// Returns
+// * _, _, err: if an error occurred while parsing the URL
+// * URL, false, nil: if URL is valid and contains no stray non-login params
+// * URL, true, nil: if URL is valid and contains stray non-login params
+func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, []string, error) {
 	// url.URL.Query return a map and therefore makes no guarantees about param order
 	// Therefore we have to ascertain the param order by inspecting the raw query
 	var urlParam *url.URL = nil // Will be url.URL for the url param
-	strayParams := false        // Will be true if stray params are found
 	urlParamDone := false       // Will be true when we're done building urlParam (but we're still checking for stray params)
+	strays := []string{}        // List of stray params
 
 	for _, param := range reAmpSemi.Split(loginURL.RawQuery, -1) {
 		paramKeyVal := strings.Split(param, "=")
@@ -142,14 +143,14 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 				// Found it
 				parsed, e := url.Parse(loginURL.Query().Get("url"))
 				if e != nil {
-					return nil, e // failure to parse url param
+					return nil, []string{}, e // failure to parse url param
 				}
 
 				urlParam = parsed
 			} else if !isVouchParam {
 				// Non-vouch param before url param is a stray param
 				log.Infof("Stray param in login request (%s)", paramKey)
-				strayParams = true
+				strays = append(strays, paramKey)
 			} // else vouch param before url param, doesn't change outcome
 		} else {
 			// Looking at params after url param
@@ -167,22 +168,22 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 			} else if !isVouchParam {
 				// Non-vouch param after vouch param is a stray param
 				log.Infof("Stray param in login request (%s)", paramKey)
-				strayParams = true
+				strays = append(strays, paramKey)
 			} // else vouch param after vouch param, doesn't change outcome
 		}
 	}
 
-	// if there were stray parameters return an error
 	log.Debugf("Login url param normalized to '%s'", urlParam)
-	if strayParams {
-		return urlParam, errLoginStrayParams
-	}
-	return urlParam, nil
+	return urlParam, strays, nil
 
 }
 
 func getValidRequestedURL(r *http.Request) (string, error) {
-	u, err := normalizeLoginURLParam(r.URL)
+	u, strays, err := normalizeLoginURLParam(r.URL)
+
+	if len(strays) > 0 {
+		log.Debugf("Stray params in login url (%+q) will be ignored", strays)
+	}
 
 	if err != nil {
 		return "", fmt.Errorf("Not a valid login URL: %w %s", errInvalidURL, err)

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -121,7 +121,7 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 	strayParams := false // Will be true if stray params are found
 	urlParamDone := false // Will be true when we're done building urlParam (but we're still checking for stray params)
 
-	for _, param := range strings.Split(loginURL.RawQuery, "&") {
+	for _, param := range regexp.MustCompile("[&;]").Split(loginURL.RawQuery, -1) {
 		paramKeyVal := strings.Split(param, "=")
 		paramKey := paramKeyVal[0]
 		lcParamKey := strings.ToLower(paramKey)

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -95,41 +95,94 @@ var (
 	errNoURL      = errors.New("no destination URL requested")
 	errInvalidURL = errors.New("requested destination URL appears to be invalid")
 	errURLNotHTTP = errors.New("requested destination URL is not a valid URL (does not begin with 'http://' or 'https://')")
+	errLoginStrayParams = errors.New("login request included unrecognized parameters")
 	errDangerQS   = errors.New("requested destination URL has a dangerous query string")
 	badStrings    = []string{"http://", "https://", "data:", "ftp://", "ftps://", "//", "javascript:"}
 )
 
+// Inspect login query params to located the url param, while taking into account that the login URL may be
+// presented in an RFC-non-compliant way (for example, it is common for the url param to
+// not have its own query params property encoded, leading to URLs like
+// http://host/login?X-Vouch-Token=token&url=http://host/path?param=value&param2=value2&vouch-failcount=value3
+// where some params -- here X-Vouch-Token and vouch-failcount -- belong to login, and some others
+// -- here param and param2 -- belong to the url param of login)
+// The algorithm is as follows:
+// * All login params starting with vouch- or x-vouch- (case insensitively) are treated as true login params
+// * All other login params are treated as non-login params
+// * All non-login params between the url param and the first true login param are folded into the url param
+// * All remaining non-login params are considered stray non-login params
+// * Error is returned if the url cannot be parsed *or* it contains stray non-login params
+// * For the benefit of unit-testing, if the url contains stray non-login params, it's 
+// returned anyway (in addition to error return)
+func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
+	// url.URL.Query return a map and therefore makes no guarantees about param order
+	// Therefore we have to ascertain the param order by inspecting the raw query
+	var urlParam *url.URL = nil // Will be url.URL for the url param
+	strayParams := false // Will be true if stray params are found
+	urlParamDone := false // Will be true when we're done building urlParam (but we're still checking for stray params)
+
+	for _, param := range strings.Split(loginURL.RawQuery, "&") {
+		paramKeyVal := strings.Split(param, "=")
+		paramKey := paramKeyVal[0]
+		lcParamKey := strings.ToLower(paramKey)
+		isVouchParam := strings.HasPrefix(lcParamKey, "vouch-") || strings.HasPrefix(lcParamKey, "x-vouch-")
+
+		if urlParam == nil {
+			// Still looking for url param
+			if paramKey == "url" {
+				// Found it
+				parsed, e := url.Parse(loginURL.Query().Get("url"))
+				if e != nil {
+					return nil, e // Straight up failure to parse url param
+				}
+
+				urlParam = parsed
+			} else if !isVouchParam {
+				// Non-vouch param before url param is a stray param
+				strayParams = true
+			} // else vouch param before url param, doesn't change outcome
+		} else {
+			// Looking at params after url param
+			if !urlParamDone && isVouchParam {
+				// First vouch param after url param 
+				urlParamDone = true
+				// But keep going to check for strays
+			} else if !urlParamDone {
+				// Non-vouch param after url and before first vouch param, fold it into urlParam
+				if urlParam.RawQuery == "" {
+					urlParam.RawQuery = param
+				} else {
+					urlParam.RawQuery = urlParam.RawQuery + "&" + param
+				}
+			} else {
+				// Non-vouch param after vouch param is a stray param
+				strayParams = true
+			}
+		}
+	}
+
+	// Check if there were stray parameters to decide whether to return an error
+	if strayParams {
+		return urlParam, errLoginStrayParams
+	} else {
+		return urlParam, nil
+	}
+
+}
+
 func getValidRequestedURL(r *http.Request) (string, error) {
-	// nginx is configured with...
-	// `return 302 https://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;`
-	// because `url=$scheme://$http_host$request_uri` might be..
-	// `url=http://protectedapp.yourdomain.com/hello?arg1=val1&arg2=val2`
-	// it causes `arg2=val2` to get lost if a regular evaluation of the `url` param is performedwith...
-	//   urlparam := r.URL.Query().Get("url")
-	// so instead we extract in manually
+	u, err := normalizeLoginURLParam(r.URL)
 
-	urlparam := r.URL.RawQuery
-	urlparam = strings.Split(urlparam, "&vouch-failcount")[0]
-	urlparam = strings.TrimPrefix(urlparam, "url=")
-	log.Debugf("raw URL is %s", urlparam)
+	if err != nil {
+		return "", fmt.Errorf("Not a valid login URL: %w %s", errInvalidURL, err)
+	}
 
-	// urlparam := r.URL.Query().Get("url")
-	// log.Debugf("url URL is %s", urlparam)
-
-	if urlparam == "" {
+	if u == nil {
 		return "", errNoURL
 	}
-	if !strings.HasPrefix(strings.ToLower(urlparam), "http://") && !strings.HasPrefix(strings.ToLower(urlparam), "https://") {
-		return "", errURLNotHTTP
-	}
-	u, err := url.Parse(urlparam)
-	if err != nil {
-		return "", fmt.Errorf("won't parse: %w %s", errInvalidURL, err)
-	}
 
-	_, err = url.ParseQuery(u.RawQuery)
-	if err != nil {
-		return "", fmt.Errorf("query string won't parse: %w %s", errInvalidURL, err)
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", errURLNotHTTP
 	}
 
 	for _, v := range u.Query() {
@@ -158,7 +211,7 @@ func getValidRequestedURL(r *http.Request) (string, error) {
 		return "", fmt.Errorf("%w: mismatch between requested destination URL and '%s.cookie.secure: %v' (the cookie is only visible to 'https' but the requested site is 'http')", errInvalidURL, cfg.Branding.LCName, cfg.Cfg.Cookie.Secure)
 	}
 
-	return urlparam, nil
+	return u.String(), nil
 }
 
 func oauthLoginURL(r *http.Request, state string) string {

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -139,6 +139,7 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 				urlParam = parsed
 			} else if !isVouchParam {
 				// Non-vouch param before url param is a stray param
+				log.Infof("Stray param in login request (%s)", paramKey)
 				strayParams = true
 			} // else vouch param before url param, doesn't change outcome
 		} else {
@@ -156,12 +157,14 @@ func normalizeLoginURLParam(loginURL *url.URL) (*url.URL, error) {
 				}
 			} else {
 				// Non-vouch param after vouch param is a stray param
+				log.Infof("Stray param in login request (%s)", paramKey)
 				strayParams = true
 			}
 		}
 	}
 
 	// Check if there were stray parameters to decide whether to return an error
+	log.Debugf("Login url param normalized to '%s'", urlParam.String())
 	if strayParams {
 		return urlParam, errLoginStrayParams
 	} else {

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -55,6 +55,11 @@ func Test_normalizeLoginURL(t *testing.T) {
 		{"all params", "http://host/login?p1=1&url=http://host/path?p2=2&p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
 		// This is an RFC-compliant URL
 		{"all params (encoded)", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
+		// This is not an RFC-compliant URL; it combines all the aspects above, and it uses semicolons as parameter separators
+		// Note that when we fold a stray param into the url param, we always do so with &s
+		{"all params (semicolons)", "http://host/login?p1=1;url=http://host/path?p2=2;p3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2&p3=3", true},
+		// This is an RFC-compliant URL that uses semicolons as parameter separators
+		{"all params (encoded, semicolons)", "http://host/login?p1=1;url=http%3a%2f%2fhost/path%3fp2=2%3bp3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2;p3=3", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -48,7 +48,7 @@ func Test_normalizeLoginURL(t *testing.T) {
 		// This is not an RFC-compliant URL; it combines all the aspects above
 		{"all params", "http://host/login?p1=1&url=http://host/path?p2=2&p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
 		// This is an RFC-compliant URL
-		{"all params", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
+		{"all params (encoded)", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -28,10 +28,6 @@ func Test_normalizeLoginURL(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		// the documentation since v0.4.0 has shown this URL in the README as the 302 redirect
-		{"as per README", "http://host/login?url=http://host/path?p2=2&vouch-failcount=3&X-Vouch-Token=TOKEN&error=anerror", "http://host/path?p2=2", false},
-		{"as per README (blanks)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2", false},
-		{"as per README (blanks, mixed with semi)", "http://host/login?url=http://host/path?p2=2;p=3&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2", false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		{"extra params", "http://host/login?url=http://host/path?p2=2", "http://host/path?p2=2", false},
 		{"extra params (blank)", "http://host/login?url=http://host/path?p2=", "http://host/path?p2=", false},
@@ -65,6 +61,11 @@ func Test_normalizeLoginURL(t *testing.T) {
 		{"all params (semicolons)", "http://host/login?p1=1;url=http://host/path?p2=2;p3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2&p3=3", true},
 		// This is an RFC-compliant URL that uses semicolons as parameter separators
 		{"all params (encoded, semicolons)", "http://host/login?p1=1;url=http%3a%2f%2fhost/path%3fp2=2%3bp3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2;p3=3", true},
+		// Real world tests
+		// There are from vouch README since c0.4.0 (recommended nginx setting for 302 redirect)
+		{"Vouch README (with error)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=3&X-Vouch-Token=TOKEN&error=anerror", "http://host/path?p2=2", false},
+		{"Vouch README (blank error)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2", false},
+		{"Vouch README (semicolons, blank error)", "http://host/login?url=http://host/path?p2=2;p3=3&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2&p3=3", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -53,9 +53,9 @@ func Test_normalizeLoginURL(t *testing.T) {
 		// Even though p1 is not a login param, we do not interpret is as part of url because it follows a login param (x-vouch-*)
 		{"params after x-vouch-* params", "http://host/login?url=http://host/path&x-vouch-xxx=2&p3=3", "http://host/path", true},
 		// This is not an RFC-compliant URL; it combines all the aspects above
-		{"all params", "http://host/login?p1=1&url=http://host/path?p2=2&p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
+		{"all params", "http://host/login?p1=1&url=http://host/path?p2=2&p3=3&x-vouch-xxx=4&vouch=5&error=6&p7=7", "http://host/path?p2=2&p3=3", true},
 		// This is an RFC-compliant URL
-		{"all params (encoded)", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&p5=5", "http://host/path?p2=2&p3=3", true},
+		{"all params (encoded)", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&vouch=5&error=6&p7=7", "http://host/path?p2=2&p3=3", true},
 		// This is not an RFC-compliant URL; it combines all the aspects above, and it uses semicolons as parameter separators
 		// Note that when we fold a stray param into the url param, we always do so with &s
 		{"all params (semicolons)", "http://host/login?p1=1;url=http://host/path?p2=2;p3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2&p3=3", true},

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/google/go-cmp/cmp"
 )
 
 func Test_normalizeLoginURL(t *testing.T) {
@@ -26,60 +27,64 @@ func Test_normalizeLoginURL(t *testing.T) {
 		name    string
 		url     string
 		want    string
+		wantStray []string
 		wantErr bool
 	}{
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
-		{"extra params", "http://host/login?url=http://host/path?p2=2", "http://host/path?p2=2", false},
-		{"extra params (blank)", "http://host/login?url=http://host/path?p2=", "http://host/path?p2=", false},
+		{"extra params", "http://host/login?url=http://host/path?p2=2", "http://host/path?p2=2", []string{}, false},
+		{"extra params (blank)", "http://host/login?url=http://host/path?p2=", "http://host/path?p2=", []string{}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// Even though the p1 param is not a login param, we do not interpret is as part of the url param because it precedes it
-		{"prior params", "http://host/login?p1=1&url=http://host/path", "http://host/path", true},
+		{"prior params", "http://host/login?p1=1&url=http://host/path", "http://host/path", []string{"p1"}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// We assume vouch-* is a login param and do not fold it into url
-		{"vouch-* params after", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", false},
+		{"vouch-* params after", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", []string{}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// We assume vouch-* is a login param and do not fold it into url
-		{"vouch-* params before", "http://host/login?vouch-xxx=1&url=http://host/path", "http://host/path", false},
+		{"vouch-* params before", "http://host/login?vouch-xxx=1&url=http://host/path", "http://host/path", []string{}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// We assume x-vouch-* is a login param and do not fold it into url
-		{"x-vouch-* params after", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", false},
+		{"x-vouch-* params after", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", []string{}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// We assume x-vouch-* is a login param and do not fold it into url
-		{"x-vouch-* params before", "http://host/login?x-vouch-xxx=1&url=http://host/path", "http://host/path", false},
+		{"x-vouch-* params before", "http://host/login?x-vouch-xxx=1&url=http://host/path", "http://host/path", []string{}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// Even though p1 is not a login param, we do not interpret is as part of url because it follows a login param (vouch-*)
-		{"params after vouch-* params", "http://host/login?url=http://host/path&vouch-xxx=2&p3=3", "http://host/path", true},
+		{"params after vouch-* params", "http://host/login?url=http://host/path&vouch-xxx=2&p3=3", "http://host/path", []string{"p3"}, false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// Even though p1 is not a login param, we do not interpret is as part of url because it follows a login param (x-vouch-*)
-		{"params after x-vouch-* params", "http://host/login?url=http://host/path&x-vouch-xxx=2&p3=3", "http://host/path", true},
+		{"params after x-vouch-* params", "http://host/login?url=http://host/path&x-vouch-xxx=2&p3=3", "http://host/path", []string{"p3"}, false},
 		// This is not an RFC-compliant URL; it combines all the aspects above
-		{"all params", "http://host/login?p1=1&url=http://host/path?p2=2&p3=3&x-vouch-xxx=4&vouch=5&error=6&p7=7", "http://host/path?p2=2&p3=3", true},
+		{"all params", "http://host/login?p1=1&url=http://host/path?p2=2&p3=3&x-vouch-xxx=4&vouch=5&error=6&p7=7", "http://host/path?p2=2&p3=3", []string{"p1", "p7"}, false},
 		// This is an RFC-compliant URL
-		{"all params (encoded)", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&vouch=5&error=6&p7=7", "http://host/path?p2=2&p3=3", true},
+		{"all params (encoded)", "http://host/login?p1=1&url=http%3a%2f%2fhost/path%3fp2=2%26p3=3&x-vouch-xxx=4&vouch=5&error=6&p7=7", "http://host/path?p2=2&p3=3", []string{"p1", "p7"}, false},
 		// This is not an RFC-compliant URL; it combines all the aspects above, and it uses semicolons as parameter separators
 		// Note that when we fold a stray param into the url param, we always do so with &s
-		{"all params (semicolons)", "http://host/login?p1=1;url=http://host/path?p2=2;p3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2&p3=3", true},
+		{"all params (semicolons)", "http://host/login?p1=1;url=http://host/path?p2=2;p3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2&p3=3", []string{"p1", "p5"}, false},
 		// This is an RFC-compliant URL that uses semicolons as parameter separators
-		{"all params (encoded, semicolons)", "http://host/login?p1=1;url=http%3a%2f%2fhost/path%3fp2=2%3bp3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2;p3=3", true},
+		{"all params (encoded, semicolons)", "http://host/login?p1=1;url=http%3a%2f%2fhost/path%3fp2=2%3bp3=3;x-vouch-xxx=4;p5=5", "http://host/path?p2=2;p3=3", []string{"p1", "p5"}, false},
 		// Real world tests
 		// since v0.4.0 the vouch README has specified an Nginx config including a 302 redirect in the following format...
-		{"Vouch Proxy README (with error)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=3&X-Vouch-Token=TOKEN&error=anerror", "http://host/path?p2=2", false},
-		{"Vouch Proxy README (blank error)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2", false},
-		{"Vouch Proxy README (semicolons, blank error)", "http://host/login?url=http://host/path?p2=2;p3=3&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2&p3=3", false},
+		{"Vouch Proxy README (with error)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=3&X-Vouch-Token=TOKEN&error=anerror", "http://host/path?p2=2", []string{}, false},
+		{"Vouch Proxy README (blank error)", "http://host/login?url=http://host/path?p2=2&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2", []string{}, false},
+		{"Vouch Proxy README (semicolons, blank error)", "http://host/login?url=http://host/path?p2=2;p3=3&vouch-failcount=&X-Vouch-Token=&error=", "http://host/path?p2=2&p3=3", []string{}, false},
 		// Nginx Ingress controler for Kubernetes adds the parameter `rd` to these calls
 		// https://github.com/vouch/vouch-proxy/issues/289
-		{"rd param appended by Nginx Ingress", "http://host/login?url=http://host/path?p2=2&p3=3&vouch-failcount=&X-Vouch-Token=&error=&rd=http%3a%2f%2fhost/path%3fp2=2%3bp3=3", "http://host/path?p2=2&p3=3", false},
+		{"rd param appended by Nginx Ingress", "http://host/login?url=http://host/path?p2=2&p3=3&vouch-failcount=&X-Vouch-Token=&error=&rd=http%3a%2f%2fhost/path%3fp2=2%3bp3=3", "http://host/path?p2=2&p3=3", []string{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			u, _ := url.Parse(tt.url)
-			got, err := normalizeLoginURLParam(u)
+			got, stray, err := normalizeLoginURLParam(u)
 			if got.String() != tt.want {
 				t.Errorf("normalizeLoginURLParam() = %v, want %v", got, tt.want)
 			}
+			if !cmp.Equal(stray, tt.wantStray) {
+				t.Errorf("normalizeLoginURLParam() stray params incorrectly parsed, got %+q, expected %+q", stray, tt.wantStray)
+			}
 			if (err != nil) != tt.wantErr {
 				t.Errorf("normalizeLoginURLParam() err = %v", err)
-			}
+			}	
 		})
 	}
 }

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -35,10 +35,16 @@ func Test_normalizeLoginURL(t *testing.T) {
 		{"prior params", "http://host/login?p1=1&url=http://host/path", "http://host/path", true},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// We assume vouch-* is a login param and do not fold it into url
-		{"vouch-* params", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", false},
+		{"vouch-* params after", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", false},
+		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
+		// We assume vouch-* is a login param and do not fold it into url
+		{"vouch-* params before", "http://host/login?vouch-xxx=1&url=http://host/path", "http://host/path", false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// We assume x-vouch-* is a login param and do not fold it into url
-		{"x-vouch-* params", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", false},
+		{"x-vouch-* params after", "http://host/login?url=http://host/path&vouch-xxx=2", "http://host/path", false},
+		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
+		// We assume x-vouch-* is a login param and do not fold it into url
+		{"x-vouch-* params before", "http://host/login?x-vouch-xxx=1&url=http://host/path", "http://host/path", false},
 		// This is not an RFC-compliant URL because it does not encode :// in the url param; we accept it anyway
 		// Even though p1 is not a login param, we do not interpret is as part of url because it follows a login param (vouch-*)
 		{"params after vouch-* params", "http://host/login?url=http://host/path&vouch-xxx=2&p3=3", "http://host/path", true},


### PR DESCRIPTION
I relaxed the stray login URL param algorithm; it now detects stray params as before, but doesn't raise an error (they are reported in the log). See #289.