### PR TITLE
Avoid inserting IdP tokens if config don't ask it for 

### DIFF
--- a/.defaults.yml
+++ b/.defaults.yml
@@ -42,8 +42,9 @@ vouch:
     redirect: X-Vouch-Requested-URI
     # claims:
     claimheader: X-Vouch-IdP-Claims-
-    accesstoken: X-Vouch-IdP-AccessToken
-    idtoken: X-Vouch-IdP-IdToken
+    # https://github.com/vouch/vouch-proxy/issues/287
+    # accesstoken: X-Vouch-IdP-AccessToken
+    # idtoken: X-Vouch-IdP-IdToken
   # test_url:
   # post_logout_redirect_uris:
 # oauth:

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -36,8 +36,8 @@ type VouchClaims struct {
 	Username     string   `json:"username"`
 	Sites        []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
 	CustomClaims map[string]interface{}
-//	PAccessToken string
-//	PIdToken     string
+	PAccessToken string
+	PIdToken     string
 	jwt.StandardClaims
 }
 
@@ -84,6 +84,15 @@ func CreateUserTokenString(u structs.User, customClaims structs.CustomClaims, pt
 		ptokens.PAccessToken,
 		ptokens.PIdToken,
 		StandardClaims,
+	}
+
+	// https://github.com/vouch/vouch-proxy/issues/287
+	if cfg.Cfg.Headers.AccessToken == "" {
+		claims.PAccessToken = ""
+	} 
+
+	if cfg.Cfg.Headers.IDToken == "" {
+		claims.PIdToken = ""
 	}
 
 	claims.StandardClaims.ExpiresAt = time.Now().Add(time.Minute * time.Duration(cfg.Cfg.JWT.MaxAge)).Unix()

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -36,8 +36,8 @@ type VouchClaims struct {
 	Username     string   `json:"username"`
 	Sites        []string `json:"sites"` // tempting to make this a map but the array is fewer characters in the jwt
 	CustomClaims map[string]interface{}
-	PAccessToken string
-	PIdToken     string
+//	PAccessToken string
+//	PIdToken     string
 	jwt.StandardClaims
 }
 


### PR DESCRIPTION
Leave IdToken and/or AccessToken empty in vouch JWT if options `vouch.headers.idtoken` and/or `vouch.headers.accesstoke` are not explicitly set in the config file.

Beware defaults values for `vouch.headers.idtoken` and `vouch.headers.accesstoke` are not set, so if you need them, put the headers name in the config file. 

This change reduce drastically vouch JWT size if you don't need the original tokens from your IdP.