### PR TITLE
Fix for example greedily matching paths

### DIFF
--- a/examples/nginx/single-file/nginx_with_vouch_single_server.conf
+++ b/examples/nginx/single-file/nginx_with_vouch_single_server.conf
@@ -38,7 +38,7 @@ http {
         ssl_certificate_key /etc/letsencrypt/live/protectedapp.yourdomain.com/privkey.pem;
 
         # This location serves all of the paths vouch uses
-        location ~ /(auth|login|logout|static) {
+        location ~ ^/(auth|login|logout|static) {
           proxy_pass http://vouch;
           proxy_set_header Host $http_host;
         }


### PR DESCRIPTION
The example nginx_with_vouch_single_server
catches all paths that include /auth etc.
this leads to unintended errors when the application has paths like
https://application/system/authentication raising a 404 from vouch