### PR TITLE
prevent redirect to other domains.

### DIFF
--- a/config/testing/handler_login_url.yml
+++ b/config/testing/handler_login_url.yml
@@ -4,6 +4,7 @@ vouch:
 
   cookie:
     secure: false
+    domain: example.com
 
   jwt:
     secret: testingsecret

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -212,7 +212,8 @@ func getValidRequestedURL(r *http.Request) (string, error) {
 	if cfg.GenOAuth.Provider != cfg.Providers.IndieAuth {
 		d := domains.Matches(hostname)
 		if d == "" {
-			if cfg.Cfg.Cookie.Domain == "" || !strings.Contains(hostname, cfg.Cfg.Cookie.Domain) {
+			inCookieDomain := (hostname == cfg.Cfg.Cookie.Domain || strings.HasSuffix(hostname, "." + cfg.Cfg.Cookie.Domain))
+			if cfg.Cfg.Cookie.Domain == "" || !inCookieDomain {
 				return "", fmt.Errorf("%w: not within a %s managed domain", errInvalidURL, cfg.Branding.FullName)
 			}
 		}

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -105,6 +105,7 @@ func Test_getValidRequestedURL(t *testing.T) {
 		{"redirection chaining escaped https://", "http://example.com/dest?url=https%3a%2f%2fsomeplaceelse.com", "", true},
 		{"data uri", "http://example.com/dest?url=data:text/plain,Example+Text", "", true},
 		{"javascript uri", "http://example.com/dest?url=javascript:alert(1)", "", true},
+		{"not in domain but contains domain", "http://example.com.somewherelse.com/", "", true},
 		{"not in domain", "http://somewherelse.com/", "", true},
 		{"should warn", "https://example.com/", "https://example.com/", false},
 		{"should be fine", "http://example.com/", "http://example.com/", false},


### PR DESCRIPTION
If cookie.domain is set to blah.com, and a redirect url is provided
as blah.com.my.custom.domain then vouch will reject it and not send
the user back to the incorrect domain.