### PR TITLE
Update systemd configs to start at boot time

### DIFF
--- a/examples/startup/systemd/vouch-proxy.service
+++ b/examples/startup/systemd/vouch-proxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Vouch Proxy
-After=vouch-proxy.service
+After=network.target
 
 [Service]
 Type=simple
@@ -13,4 +13,4 @@ StartLimitInterval=60s
 StartLimitBurst=3
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
The current configurations won't start vouch-proxy after a system reboot