### PR TITLE
Multiple oauth configs

### DIFF
--- a/.defaults.yml
+++ b/.defaults.yml
@@ -10,6 +10,8 @@ vouch:
   listen: 0.0.0.0
   port: 9090
   # domains:
+  #   - uri:
+  #   - service:
   allowAllUsers: false
   publicAccess: false
   # whiteList:
@@ -53,14 +55,16 @@ vouch:
   # test_url:
   # post_logout_redirect_uris:
 # oauth:
-#   provider:
-#   client_id:
-#   client_secret:
-#   callback_url:
-#   callback_urls:
-#   preferredDomain:
-#   auth_url:
-#   token_url:
-#   user_info_url:
-#   end_session_endpoint:
-#   scopes:
+#   services:
+#     - id:
+#       provider:
+#       client_id:
+#       client_secret:
+#       callback_url:
+#       callback_urls:
+#       preferredDomain:
+#       auth_url:
+#       token_url:
+#       user_info_url:
+#       end_session_endpoint:
+#       scopes:

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -29,8 +29,10 @@ vouch:
   # usually you'll just have one.
   # Comment `domains:` out if you set allowAllUser:true
   domains:
-  - yourdomain.com
-  - yourotherdomain.com
+  - Uri: yourdomain.com
+    Service: GenericOpenIdService
+  - Uri: yourotherdomain.com
+    Service: IndieAuthService
 
   # Set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider - VOUCH_ALLOWALLUSERS
   # allowAllUsers: false
@@ -186,65 +188,61 @@ vouch:
 #   scopes:                  OAUTH_SCOPES
 #   code_challenge_method:   OAUTH_CODE_CHALLENGE_METHOD
 
-#
-# configure ONLY ONE of the following oauth providers
-#
-
 oauth:
+  Services:
+    - id: GoogleService
+      provider: google
+      # create new credentials at:
+      # https://console.developers.google.com/apis/credentials
+      client_id:
+      client_secret:
+      callback_urls:
+        - http://vouch.yourdomain.com:9090/auth
+        - http://vouch.yourotherdomain.com:9090/auth
+      preferredDomain: yourdomain.com
+      # optionally set scopes, defaults to 'email'
+      # https://developers.google.com/identity/protocols/googlescopes#google_sign-in
+      # scopes:
+      #  - email
 
-  # Google
-  provider: google
-  # create new credentials at:
-  # https://console.developers.google.com/apis/credentials
-  client_id: 
-  client_secret: 
-  callback_urls:
-    - http://vouch.yourdomain.com:9090/auth
-    - http://vouch.yourotherdomain.com:9090/auth
-  preferredDomain: yourdomain.com
-  # optionally set scopes, defaults to 'email'
-  # https://developers.google.com/identity/protocols/googlescopes#google_sign-in
-  # scopes:
-  #  - email
+    - id: GitHubService
+      # https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
+      provider: github
+      client_id:
+      client_secret:
+      # callback_url is configured at github.com when setting up the app
+      # Set to e.g. https://vouch.yourdomain.com/auth
+      # defaults (uncomment and change these if you are using github enterprise on-prem)
+      # auth_url: https://github.com/login/oauth/authorize
+      # token_url: https://github.com/login/oauth/access_token
+      # user_info_url: https://api.github.com/user?access_token=
+      # scopes:
+        # - user
 
-  # GitHub
-  # https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
-  provider: github
-  client_id:
-  client_secret:
-  # callback_url is configured at github.com when setting up the app
-  # Set to e.g. https://vouch.yourdomain.com/auth
-  # defaults (uncomment and change these if you are using github enterprise on-prem)
-  # auth_url: https://github.com/login/oauth/authorize
-  # token_url: https://github.com/login/oauth/access_token
-  # user_info_url: https://api.github.com/user?access_token=
-  # scopes:
-    # - user
+    GenericOpenIdService:
+      provider: oidc
+      client_id:
+      client_secret:
+      auth_url: https://{yourOktaDomain}/oauth2/default/v1/authorize
+      token_url: https://{yourOktaDomain}/oauth2/default/v1/token
+      user_info_url: https://{yourOktaDomain}/oauth2/default/v1/userinfo
+      # end_session_endpoint is usually the IdP's logout URL
+      # see https://github.com/vouch/vouch-proxy/pull/258
+      end_session_endpoint: https://{yourOktaDomain}/oauth2/default/v1/logout
+      scopes:
+        - openid
+        - email
+        - profile
+      callback_url: http://vouch.yourdomain.com:9090/auth
+      # PKCE method if enabled, S256 is currently supported (check https://www.oauth.com/oauth2-servers/pkce/)
+      # resolves issue https://github.com/vouch/vouch-proxy/issues/303
+      code_challenge_method: S256
 
-  # Generic OpenID Connect
-  provider: oidc
-  client_id: 
-  client_secret: 
-  auth_url: https://{yourOktaDomain}/oauth2/default/v1/authorize
-  token_url: https://{yourOktaDomain}/oauth2/default/v1/token
-  user_info_url: https://{yourOktaDomain}/oauth2/default/v1/userinfo
-  # end_session_endpoint is usually the IdP's logout URL
-  # see https://github.com/vouch/vouch-proxy/pull/258
-  end_session_endpoint: https://{yourOktaDomain}/oauth2/default/v1/logout
-  scopes:
-    - openid
-    - email
-    - profile
-  callback_url: http://vouch.yourdomain.com:9090/auth
-  # PKCE method if enabled, S256 is currently supported (check https://www.oauth.com/oauth2-servers/pkce/)
-  # resolves issue https://github.com/vouch/vouch-proxy/issues/303
-  code_challenge_method: S256
-
-  # IndieAuth
-  # https://indielogin.com/api
-  provider: indieauth
-  client_id: http://yourdomain.com
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.yourdomain.com:9090/auth
+    IndieAuthService:
+      # https://indielogin.com/api
+      provider: indieauth
+      client_id: http://yourdomain.com
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.yourdomain.com:9090/auth
 
 

--- a/config/config.yml_example_adfs
+++ b/config/config.yml_example_adfs
@@ -13,13 +13,15 @@ vouch:
 
 
 oauth:
-  provider: adfs
-  client_id: k8s
-  client_secret: sauceSecret
-  auth_url: https://adfs.yourdomain.com/adfs/oauth2/authorize/
-  token_url: https://adfs.yourdomain.com/adfs/oauth2/token/
-  scopes:
-    - openid
-    - email
-    - profile
-  callback_url: https://vouch.yourdomain.com/auth
+  Services:
+    - id: adfsService
+      provider: adfs
+      client_id: k8s
+      client_secret: sauceSecret
+      auth_url: https://adfs.yourdomain.com/adfs/oauth2/authorize/
+      token_url: https://adfs.yourdomain.com/adfs/oauth2/token/
+      scopes:
+        - openid
+        - email
+        - profile
+      callback_url: https://vouch.yourdomain.com/auth

--- a/config/config.yml_example_azure
+++ b/config/config.yml_example_azure
@@ -13,13 +13,15 @@ vouch:
     #  domain: yourdomain.com
 
 oauth:
-  provider: azure
-  client_id: 123456789
-  client_secret: ********
-  auth_url: https://login.microsoftonline.com/.../oauth2/v2.0/authorize
-  token_url: https://login.microsoftonline.com/.../oauth2/v2.0/token
-  scopes:
-    - openid
-    - email
-    - profile
-  callback_url: https://vouch.yourdomain/auth
+  Services:
+    - id: azureService
+      provider: azure
+      client_id: 123456789
+      client_secret: ********
+      auth_url: https://login.microsoftonline.com/.../oauth2/v2.0/authorize
+      token_url: https://login.microsoftonline.com/.../oauth2/v2.0/token
+      scopes:
+        - openid
+        - email
+        - profile
+      callback_url: https://vouch.yourdomain/auth

--- a/config/config.yml_example_gitea
+++ b/config/config.yml_example_gitea
@@ -4,7 +4,8 @@
 
 vouch:
   domains:
-  - yourdomain.com
+  - Uri: yourdomain.com
+    Service: giteaService
 
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at Gitea
   # allowAllUsers: true
@@ -17,13 +18,15 @@ vouch:
 
 
 oauth:
-  # replace "gitea.yourdomain.com" with the domain your Gitea instance runs on
-  # create a new OAuth application at:
-  # https://gitea.yourdomain.com/user/settings/applications
-  provider: github
-  client_id: xxxxxxxxxxxxxxxxxxxx
-  client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  auth_url: https://gitea.yourdomain.com/login/oauth/authorize
-  token_url: https://gitea.yourdomain.com/login/oauth/access_token
-  user_info_url: https://gitea.yourdomain.com/api/v1/user?token=
-  callback_url: https://yourdomain.com/auth
+  Services:
+    - id: giteaService
+      # replace "gitea.yourdomain.com" with the domain your Gitea instance runs on
+      # create a new OAuth application at:
+      # https://gitea.yourdomain.com/user/settings/applications
+      provider: github
+      client_id: xxxxxxxxxxxxxxxxxxxx
+      client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      auth_url: https://gitea.yourdomain.com/login/oauth/authorize
+      token_url: https://gitea.yourdomain.com/login/oauth/access_token
+      user_info_url: https://gitea.yourdomain.com/api/v1/user?token=
+      callback_url: https://yourdomain.com/auth

--- a/config/config.yml_example_github
+++ b/config/config.yml_example_github
@@ -10,7 +10,8 @@ vouch:
   # https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/#redirect-urls
   # each of these domains must serve the url https://login.$domains[0] https://login.$domains[1] ...
   domains:
-  - yourothersite.io
+  - Uri: yourothersite.io
+    Service: githubService
 
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at GitHub
   # allowAllUsers: true
@@ -34,9 +35,11 @@ vouch:
   # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included
 
 oauth:
-  # create a new OAuth application at:
-  # https://github.com/settings/applications/new
-  provider: github
-  client_id: xxxxxxxxxxxxxxxxxxxx
-  client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  # endpoints set from https://godoc.org/golang.org/x/oauth2/github
+  Services:
+    - id: githubService
+      # create a new OAuth application at:
+      # https://github.com/settings/applications/new
+      provider: github
+      client_id: xxxxxxxxxxxxxxxxxxxx
+      client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      # endpoints set from https://godoc.org/golang.org/x/oauth2/github

--- a/config/config.yml_example_github_enterprise
+++ b/config/config.yml_example_github_enterprise
@@ -8,8 +8,10 @@ vouch:
   # each of these domains must serve the url https://login.$domains[0] https://login.$domains[1] ...
   # the callback_urls will be to these domains
   domains:
-  - yourdomain.com
-  - yourothersite.io
+  - Uri: yourdomain.com
+    Service: githubEnterpriseService
+  - Uri: yourothersite.io
+    Service: githubEnterpriseService
 
   # - OR -
   # instead of setting specific domains you may prefer to allow all users...
@@ -35,19 +37,21 @@ vouch:
   # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included
 
 oauth:
-  # create a new OAuth application at:
-  # https://githubenterprise.yourdomain.com/settings/applications/new
-  provider: github
-  client_id: xxxxxxxxxxxxxxxxxxxx
-  client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  auth_url: https://githubenterprise.yourdomain.com/login/oauth/authorize
-  token_url: https://githubenterprise.yourdomain.com/login/oauth/access_token
-  user_info_url: https://githubenterprise.yourdomain.com/api/v3/user?access_token=
-  # relevant only if teamWhitelist is configured; colon-prefixed parts are parameters that
-  # will be replaced with the respective values.
-  user_team_url: https://githubenterprise.yourdomain.com/api/v3/orgs/:org_id/teams/:team_slug/memberships/:username?access_token=
-  user_org_url: https://githubenterprise.yourdomain.com/api/v3/orgs/:org_id/members/:username?access_token=
-  # these GitHub OAuth defaults are set for you..
-  # scopes:
-  #   - user
-  # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included
+  Services:
+    - id: githubEnterpriseService
+      # create a new OAuth application at:
+      # https://githubenterprise.yourdomain.com/settings/applications/new
+      provider: github
+      client_id: xxxxxxxxxxxxxxxxxxxx
+      client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      auth_url: https://githubenterprise.yourdomain.com/login/oauth/authorize
+      token_url: https://githubenterprise.yourdomain.com/login/oauth/access_token
+      user_info_url: https://githubenterprise.yourdomain.com/api/v3/user?access_token=
+      # relevant only if teamWhitelist is configured; colon-prefixed parts are parameters that
+      # will be replaced with the respective values.
+      user_team_url: https://githubenterprise.yourdomain.com/api/v3/orgs/:org_id/teams/:team_slug/memberships/:username?access_token=
+      user_org_url: https://githubenterprise.yourdomain.com/api/v3/orgs/:org_id/members/:username?access_token=
+      # these GitHub OAuth defaults are set for you..
+      # scopes:
+      #   - user
+      # In case both vouch.teamWhitelist AND oauth.scopes is configured, make sure read:org scope is included

--- a/config/config.yml_example_google
+++ b/config/config.yml_example_google
@@ -4,8 +4,10 @@
 
 vouch:
   domains:
-  - yourdomain.com
-  - yourotherdomain.com
+  - Uri: yourdomain.com
+    Service: googleService
+  - Uri: yourotherdomain.com
+    Service: googleService
 
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at Gitea
   # allowAllUsers: true
@@ -18,13 +20,15 @@ vouch:
 
 
 oauth:
-  provider: google
-  # get credentials from...
-  # https://console.developers.google.com/apis/credentials
-  client_id: xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
-  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
-  callback_urls: 
-    - http://yourdomain.com:9090/auth
-    - http://yourotherdomain.com:9090/auth
-  preferredDomain: yourdomain.com # be careful with this option, it may conflict with chrome on Android 
-  # endpoints are set from https://godoc.org/golang.org/x/oauth2/google
+  Services:
+    - id: googleService
+      provider: google
+      # get credentials from...
+      # https://console.developers.google.com/apis/credentials
+      client_id: xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
+      client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+      callback_urls:
+        - http://yourdomain.com:9090/auth
+        - http://yourotherdomain.com:9090/auth
+      preferredDomain: yourdomain.com # be careful with this option, it may conflict with chrome on Android
+      # endpoints are set from https://godoc.org/golang.org/x/oauth2/google

--- a/config/config.yml_example_homeassistant
+++ b/config/config.yml_example_homeassistant
@@ -9,7 +9,8 @@ vouch:
   # valid domains that the jwt cookies can be set into
   # the callback_urls will be to these domains
   domains:
-  - yourdomain.com
+  - Uri: yourdomain.com
+    Service: homeassistantService
 
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at Gitea
   # allowAllUsers: true
@@ -26,12 +27,14 @@ vouch:
   - homeassistant
 
 oauth:
-  # HomeAssistant Auth
-  # HomeAssistant typically uses a port in the url (8123 by default) and this maybe required for the auth_url and token_url 
-  # depending on your setup of HA
-  # https://developers.home-assistant.io/docs/en/auth_api.html
-  provider: homeassistant
-  client_id: https://vouch.yourdomain.com
-  callback_url: https://vouch.yourdomain.com/auth
-  auth_url: https://homeassistant.yourdomain.com:port/auth/authorize
-  token_url: https://homeassistant.yourdomain.com:port/auth/token
+  Services:
+    - id: homeassistantService
+      # HomeAssistant Auth
+      # HomeAssistant typically uses a port in the url (8123 by default) and this maybe required for the auth_url and token_url
+      # depending on your setup of HA
+      # https://developers.home-assistant.io/docs/en/auth_api.html
+      provider: homeassistant
+      client_id: https://vouch.yourdomain.com
+      callback_url: https://vouch.yourdomain.com/auth
+      auth_url: https://homeassistant.yourdomain.com:port/auth/authorize
+      token_url: https://homeassistant.yourdomain.com:port/auth/token

--- a/config/config.yml_example_indieauth
+++ b/config/config.yml_example_indieauth
@@ -7,7 +7,8 @@ vouch:
   # valid domains that the jwt cookies can be set into
   # the callback_urls will be to these domains
   # domains:
-  # - yourdomain.com
+  # - Uri: yourdomain.com
+    Service: indieAuthService
 
   # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
   allowAllUsers: true
@@ -22,9 +23,11 @@ vouch:
   publicAccess: true
 
 oauth:
-  # IndieAuth
-  # https://indielogin.com/api
-  provider: indieauth
-  client_id: http://yourdomain.com
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.yourdomain.com:9090/auth
+  Services:
+    - id: indieAuthService
+      # IndieAuth
+      # https://indielogin.com/api
+      provider: indieauth
+      client_id: http://yourdomain.com
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.yourdomain.com:9090/auth

--- a/config/config.yml_example_nextcloud
+++ b/config/config.yml_example_nextcloud
@@ -7,8 +7,10 @@ vouch:
   # valid domains that the jwt cookies can be set into
   # the callback_urls will be to these domains
   domains:
-  - yourdomain.com
-  - yourotherdomain.com
+  - Uri: yourdomain.com
+    Service: nextcloudService
+  - Uri: yourotherdomain.com
+    Service: nextcloudService
 
   # - OR -
   # instead of setting specific domains you may prefer to allow all users...
@@ -22,16 +24,18 @@ vouch:
     # domain: yourdomain.com
 
 oauth:
-  # This assumes usage of pretty URLs otherwise add /index.php/
-  # to start of URL path
-  provider: nextcloud
-  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
-  auth_url: https://nextcloud.yourdomain.com/apps/oauth2/authorize
-  token_url: https://nextcloud.yourdomain.com/apps/oauth2/api/v1/token
-  user_info_url: https://nextcloud.yourdomain.com/ocs/v2.php/cloud/user?format=json
-  scopes:
-    - openid
-    - email
-    - profile
-  callback_url: http://vouch.yourdomain.com:9090/auth
+  Services:
+    - id: nextcloudService
+      # This assumes usage of pretty URLs otherwise add /index.php/
+      # to start of URL path
+      provider: nextcloud
+      client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+      auth_url: https://nextcloud.yourdomain.com/apps/oauth2/authorize
+      token_url: https://nextcloud.yourdomain.com/apps/oauth2/api/v1/token
+      user_info_url: https://nextcloud.yourdomain.com/ocs/v2.php/cloud/user?format=json
+      scopes:
+        - openid
+        - email
+        - profile
+      callback_url: http://vouch.yourdomain.com:9090/auth

--- a/config/config.yml_example_oidc
+++ b/config/config.yml_example_oidc
@@ -7,8 +7,10 @@ vouch:
   # valid domains that the jwt cookies can be set into
   # the callback_urls will be to these domains
   domains:
-  - yourdomain.com
-  - yourotherdomain.com
+  - Uri: yourdomain.com
+    Service: oidcService
+  - Uri: yourotherdomain.com
+    Service: oidcService
 
   # - OR -
   # instead of setting specific domains you may prefer to allow all users...
@@ -23,16 +25,18 @@ vouch:
     # domain: yourdomain.com
 
 oauth:
-  # Generic OpenID Connect
-  # including okta
-  provider: oidc
-  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
-  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
-  auth_url: https://{yourOktaDomain}/oauth2/default/v1/authorize
-  token_url: https://{yourOktaDomain}/oauth2/default/v1/token
-  user_info_url: https://{yourOktaDomain}/oauth2/default/v1/userinfo
-  scopes:
-    - openid
-    - email
-    - profile
-  callback_url: http://vouch.yourdomain.com:9090/auth
+  Services:
+    - id: oidcService
+      # Generic OpenID Connect
+      # including okta
+      provider: oidc
+      client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+      client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+      auth_url: https://{yourOktaDomain}/oauth2/default/v1/authorize
+      token_url: https://{yourOktaDomain}/oauth2/default/v1/token
+      user_info_url: https://{yourOktaDomain}/oauth2/default/v1/userinfo
+      scopes:
+        - openid
+        - email
+        - profile
+      callback_url: http://vouch.yourdomain.com:9090/auth

--- a/config/config.yml_example_scopes_and_claims
+++ b/config/config.yml_example_scopes_and_claims
@@ -15,9 +15,10 @@ vouch:
       - email_verified
 
 oauth:
-  # .... your provider config goes here
-  scopes:
-    # make sure to set the required scopes
-    - openid
-    - email
-    - profile
+  Services:
+    - # .... your provider config goes here
+      scopes:
+        # make sure to set the required scopes
+        - openid
+        - email
+        - profile

--- a/config/testing/handler_allowallusers.yml
+++ b/config/testing/handler_allowallusers.yml
@@ -5,7 +5,9 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_claims.yml
+++ b/config/testing/handler_claims.yml
@@ -23,7 +23,9 @@ vouch:
     secret: testing
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_email.yml
+++ b/config/testing/handler_email.yml
@@ -1,13 +1,16 @@
 vouch:
   logLevel: error
   domains:
-    - example.com
+    - Uri: example.com
+      Service: test_service
 
   jwt:
     secret: testingsecret
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_login_redirecturls.yml
+++ b/config/testing/handler_login_redirecturls.yml
@@ -1,7 +1,9 @@
 vouch:
   domains:
-    - example.com
-    - other.com
+    - Uri: example.com
+      Service: test_service
+    - Uri: other.com
+      Service: test_service
 
   cookie:
     secure: false
@@ -10,10 +12,12 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: google
-  client_id: 1234567
-  client_secret: testingsecret
-  auth_url: https://indielogin.com/auth
-  callback_urls:
-    - http://vouch.example.com:9090/auth
-    - http://vouch.other.com:9090/auth
+  Services:
+    - id: test_service
+      provider: google
+      client_id: 1234567
+      client_secret: testingsecret
+      auth_url: https://indielogin.com/auth
+      callback_urls:
+        - http://vouch.example.com:9090/auth
+        - http://vouch.other.com:9090/auth

--- a/config/testing/handler_login_url.yml
+++ b/config/testing/handler_login_url.yml
@@ -1,6 +1,7 @@
 vouch:
   domains:
-    - example.com
+    - Uri: example.com
+      Service: test_service
 
   cookie:
     secure: false
@@ -10,7 +11,9 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: google
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: google
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_logout_provider.yml
+++ b/config/testing/handler_logout_provider.yml
@@ -1,6 +1,7 @@
 vouch:
   domains:
-    - example.com
+    - Uri: example.com
+      Service: test_service
 
   cookie:
     secure: false
@@ -14,8 +15,10 @@ vouch:
     - https://oauth2.googleapis.com/revoke
 
 oauth:
-  provider: google
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
-  end_session_endpoint: https://indielogin.com/logout
+  Services:
+    - id: test_service
+      provider: google
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth
+      end_session_endpoint: https://indielogin.com/logout

--- a/config/testing/handler_logout_url.yml
+++ b/config/testing/handler_logout_url.yml
@@ -1,6 +1,7 @@
 vouch:
   domains:
-    - example.com
+    - Uri: example.com
+      Service: test_service
 
   cookie:
     secure: false
@@ -14,7 +15,9 @@ vouch:
     - https://oauth2.googleapis.com/revoke
 
 oauth:
-  provider: google
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: google
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_nodomains.yml
+++ b/config/testing/handler_nodomains.yml
@@ -3,7 +3,9 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_teams.yml
+++ b/config/testing/handler_teams.yml
@@ -1,7 +1,8 @@
 vouch:
   logLevel: debug
   domains:
-    - example.com
+    - Uri: example.com
+      Service: test_service
 
   teamWhitelist:
     - "org1/team1"
@@ -11,7 +12,9 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: github
-  client_id: fake
-  auth_url: fake
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: github
+      client_id: fake
+      auth_url: fake
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/handler_whitelist.yml
+++ b/config/testing/handler_whitelist.yml
@@ -1,7 +1,8 @@
 vouch:
   logLevel: debug
   domains:
-    - example.com
+    - Uri: example.com
+      Service: test_service
 
   whiteList:
     - test@example.com
@@ -10,7 +11,9 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/jwtmanager_has_idp_token_claims.yml
+++ b/config/testing/jwtmanager_has_idp_token_claims.yml
@@ -25,7 +25,9 @@ vouch:
     secret: testing
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/logging_debug.yml
+++ b/config/testing/logging_debug.yml
@@ -3,7 +3,9 @@ vouch:
   allowAllUsers: true
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/logging_error.yml
+++ b/config/testing/logging_error.yml
@@ -3,7 +3,9 @@ vouch:
   allowAllUsers: true
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/logging_info.yml
+++ b/config/testing/logging_info.yml
@@ -3,7 +3,9 @@ vouch:
   allowAllUsers: true
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/logging_warn.yml
+++ b/config/testing/logging_warn.yml
@@ -3,7 +3,9 @@ vouch:
   allowAllUsers: true
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/minimal.yml
+++ b/config/testing/minimal.yml
@@ -2,7 +2,9 @@ vouch:
   allowAllUsers: true
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/config/testing/test_config.yml
+++ b/config/testing/test_config.yml
@@ -3,7 +3,8 @@ vouch:
   listen: 0.0.0.0
   port: 9090
   domains:
-    - vouch.github.io
+    - Uri: vouch.github.io
+      Service: test_service
 
   whiteList:
     - bob@yourdomain.com
@@ -20,7 +21,9 @@ vouch:
     secret: testingsecret
 
 oauth:
-  provider: indieauth
-  client_id: http://vouch.github.io
-  auth_url: https://indielogin.com/auth
-  callback_url: http://vouch.github.io:9090/auth
+  Services:
+    - id: test_service
+      provider: indieauth
+      client_id: http://vouch.github.io
+      auth_url: https://indielogin.com/auth
+      callback_url: http://vouch.github.io:9090/auth

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -35,7 +35,7 @@ import (
 // Provider each Provider must support GetuserInfo
 type Provider interface {
 	Configure()
-	GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) error
+	GetUserInfo(config cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) error
 }
 
 const (

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -34,8 +34,8 @@ import (
 
 // Provider each Provider must support GetuserInfo
 type Provider interface {
-	Configure()
-	GetUserInfo(config cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) error
+	Configure(config *cfg.OauthConfig)
+	GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) error
 }
 
 const (

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -46,7 +46,7 @@ var (
 	sessstore *sessions.CookieStore
 	log       *zap.SugaredLogger
 	fastlog   *zap.Logger
-	provider  Provider
+	providers = make(map[string]Provider)
 )
 
 // Configure see main.go configure()
@@ -60,13 +60,16 @@ func Configure() {
 	sessstore.Options.SameSite = cookie.SameSite()
 	sessstore.Options.MaxAge = 300 // give the user five minutes to log in at the IdP
 
-	provider = getProvider()
-	provider.Configure()
+	for _, service := range (*cfg.GenOAuth).Services {
+		provider := getProvider(service.Provider)
+		provider.Configure()
+		providers[service.Id] = provider
+	}
 	common.Configure()
 }
 
-func getProvider() Provider {
-	switch cfg.GenOAuth.Provider {
+func getProvider(Provider string) Provider {
+	switch Provider {
 	case cfg.Providers.IndieAuth:
 		return indieauth.Provider{}
 	case cfg.Providers.ADFS:

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -34,7 +34,7 @@ var (
 // setUp load config file and then call Configure() for dependent packages
 func setUp(configFile string) {
 	os.Setenv("VOUCH_CONFIG", filepath.Join(os.Getenv("VOUCH_ROOT"), configFile))
-	cfg.InitForTestPurposes()
+	cfg.InitForTestPurposes(nil)
 
 	Configure()
 	domains.Configure()
@@ -96,7 +96,7 @@ func TestVerifyUserPositiveNoDomainsConfigured(t *testing.T) {
 	setUp("/config/testing/handler_nodomains.yml")
 
 	user := &structs.User{Username: "testuser", Email: "test@example.com", Name: "Test Name"}
-	cfg.Cfg.Domains = make([]string, 0)
+	cfg.Cfg.Domains = make([]cfg.DomainOptions, 0)
 	ok, err := verifyUser(*user)
 
 	assert.True(t, ok)

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -23,7 +23,6 @@ import (
 	"github.com/theckman/go-securerandom"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/cookie"
-	"github.com/vouch/vouch-proxy/pkg/domains"
 	"github.com/vouch/vouch-proxy/pkg/responses"
 	"golang.org/x/oauth2"
 )
@@ -218,7 +217,7 @@ func getValidRequestedURL(r *http.Request) (string, error) {
 
 	hostname := u.Hostname()
 	if cfg.GenOAuth.Provider != cfg.Providers.IndieAuth {
-		d := domains.Matches(hostname)
+		d := cfg.Matches(hostname)
 		if d == "" {
 			inCookieDomain := (hostname == cfg.Cfg.Cookie.Domain || strings.HasSuffix(hostname, "." + cfg.Cfg.Cookie.Domain))
 			if cfg.Cfg.Cookie.Domain == "" || !inCookieDomain {
@@ -248,7 +247,7 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 	// this checks the multiple redirect case for multiple matching domains
 	if len(cfg.GenOAuth.RedirectURLs) > 0 {
 		found := false
-		domain := domains.Matches(r.Host)
+		domain := cfg.Matches(r.Host)
 		log.Debugf("/login looking for callback_url matching %s", domain)
 		for _, v := range cfg.GenOAuth.RedirectURLs {
 			if strings.Contains(v, domain) {

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -117,11 +117,13 @@ func Test_getValidRequestedURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r.URL, _ = url.Parse("http://vouch.example.com/login?url=" + tt.url)
 			got, err := getValidRequestedURL(r)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getValidRequestedURL() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("getValidRequestedURL() error = %v, wantErr %v", err, tt.wantErr)
+				}
 				return
 			}
-			if got != tt.want {
+			if (*got).String() != tt.want {
 				t.Errorf("getValidRequestedURL() = %v, want %v", got, tt.want)
 			}
 		})

--- a/handlers/login_test.go
+++ b/handlers/login_test.go
@@ -148,6 +148,7 @@ func TestLoginHandler(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			req.Host = "myapp.example.com"
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 

--- a/handlers/logout.go
+++ b/handlers/logout.go
@@ -52,7 +52,13 @@ func LogoutHandler(w http.ResponseWriter, r *http.Request) {
 		log.Error(err)
 	}
 
-	providerLogoutURL := cfg.GenOAuth.LogoutURL
+	service, _, err := cfg.GetServiceForHostname(r.Host)
+	if err != nil {
+		responses.Error403(w, r, err)
+		return
+	}
+
+	providerLogoutURL := service.LogoutURL
 	redirectURL := r.URL.Query().Get("url")
 
 	// Make sure that redirectURL, if given, is allowed by config

--- a/handlers/logout_test.go
+++ b/handlers/logout_test.go
@@ -80,7 +80,11 @@ func TestProviderLogoutHandler(t *testing.T) {
 			}
 			if rr.Code == http.StatusFound {
 				wanted := tt.url
-				req, _ := http.NewRequest("GET", cfg.GenOAuth.LogoutURL, nil)
+				service, _, err := cfg.GetServiceForHostname(req.Host)
+				if err != nil {
+					t.Fatal(err)
+				}
+				req, _ := http.NewRequest("GET", service.LogoutURL, nil)
 
 				q := req.URL.Query()
 				q.Add("post_logout_redirect_uri", wanted)

--- a/handlers/logout_test.go
+++ b/handlers/logout_test.go
@@ -81,11 +81,11 @@ func TestProviderLogoutHandler(t *testing.T) {
 			}
 			if rr.Code == http.StatusFound {
 				wanted := tt.url
-				service, _, err := cfg.GetServiceForHostname(req.Host)
+				config, err := cfg.GetConfigForHostname(req.Host)
 				if err != nil {
 					t.Fatal(err)
 				}
-				req, _ := http.NewRequest("GET", service.LogoutURL, nil)
+				req, _ := http.NewRequest("GET", config.LogoutURL, nil)
 
 				q := req.URL.Query()
 				q.Add("post_logout_redirect_uri", wanted)

--- a/handlers/logout_test.go
+++ b/handlers/logout_test.go
@@ -73,6 +73,7 @@ func TestProviderLogoutHandler(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			req.Host = "myapp.example.com"
 			rr := httptest.NewRecorder()
 			handler.ServeHTTP(rr, req)
 			if rr.Code != tt.wantcode {

--- a/main.go
+++ b/main.go
@@ -126,8 +126,8 @@ func main() {
 		"branch", branch,
 		"semver", semver,
 		"listen", scheme[tls]+"://"+listen,
-		"tls", tls,
-		"oauth.provider", cfg.GenOAuth.Provider)
+		"tls", tls)
+	// "oauth.provider", cfg.GenOAuth.Provider)
 
 	muxR := mux.NewRouter()
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -521,5 +521,25 @@ func InitForTestPurposesWithProvider(provider string) {
 		setProviderDefaults()
 	}
 	cleanClaimsHeaders()
+}
 
+// Matches returns one of the domains we're configured for
+func Matches(s string) string {
+	if strings.Contains(s, ":") {
+		// then we have a port and we just want to check the host
+		split := strings.Split(s, ":")
+		log.Debugf("removing port from %s to test domain %s", s, split[0])
+		s = split[0]
+	}
+
+	if len(Cfg.Domains) > 0 {
+		for i, v := range Cfg.Domains {
+			if s == v.Uri || strings.HasSuffix(s, "."+v.Uri) {
+				log.Debugf("domain %s matched array value at [%d]=%v", s, i, v)
+				return v.Uri
+			}
+		}
+		log.Warnf("domain %s not found in any domains %v", s, Cfg.Domains.String())
+	}
+	return ""
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -181,9 +181,8 @@ func Configure() {
 
 	fixConfigOptions()
 	Logging.configure()
-	if err := configureOauth(); err == nil {
-		setProviderDefaults()
-	}
+	ConfigureOauth()
+
 	cleanClaimsHeaders()
 	if *CmdLine.port != -1 {
 		Cfg.Port = *CmdLine.port
@@ -511,9 +510,7 @@ func InitForTestPurposesWithProvider(provider string) {
 	setDefaults()
 	parseConfigFile()
 	configureFromEnv()
-	if err := configureOauth(); err == nil {
-		setProviderDefaults()
-	}
+	ConfigureOauth()
 	fixConfigOptions()
 
 	// setDevelopmentLogger()

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -50,8 +50,8 @@ func TestConfigEnvPrecedence(t *testing.T) {
 	// Configure()
 	setUp("/config/testing/handler_login_url.yml")
 
-	service := GenOAuth.Services[0]
-	assert.Equal(t, SECRET, service.ClientSecret)
+	config := GenOAuth.GetConfig(0)
+	assert.Equal(t, SECRET, config.ClientSecret)
 
 	// assert.NotEmpty(t, Cfg.JWT.MaxAge)
 
@@ -84,19 +84,19 @@ func TestConfigWithTLS(t *testing.T) {
 }
 func TestSetGitHubDefaults(t *testing.T) {
 	InitForTestPurposesWithProvider("github", nil)
-	service := GenOAuth.Services[0]
-	assert.Equal(t, []string{"read:user"}, service.Scopes)
+	config := GenOAuth.GetConfig(0)
+	assert.Equal(t, []string{"read:user"}, config.Scopes)
 }
 
 func TestSetGitHubDefaultsWithTeamWhitelist(t *testing.T) {
 	InitForTestPurposesWithProvider("github", nil)
 	Cfg.TeamWhiteList = append(Cfg.TeamWhiteList, "org/team")
-	service := GenOAuth.Services[0]
-	service.Scopes = []string{}
+	config := GenOAuth.GetConfig(0)
+	config.Scopes = []string{}
 
-	setDefaultsGitHub(&service)
-	assert.Contains(t, service.Scopes, "read:user")
-	assert.Contains(t, service.Scopes, "read:org")
+	config.setDefaultsGitHub()
+	assert.Contains(t, config.Scopes, "read:user")
+	assert.Contains(t, config.Scopes, "read:org")
 }
 
 func Test_claimToHeader(t *testing.T) {
@@ -256,25 +256,25 @@ func Test_configureFromEnvOAuth(t *testing.T) {
 	var scfgs [][]string
 	var sacfgs [][][]string
 
-	for _, service := range GenOAuth.Services {
+	GenOAuth.IterConfigs(func(config *OauthConfig) {
 		scfgs = append(scfgs, []string{
-			service.Provider,
-			service.ClientID,
-			service.ClientSecret,
-			service.AuthURL,
-			service.TokenURL,
-			service.LogoutURL,
-			service.RedirectURL,
-			service.UserInfoURL,
-			service.UserTeamURL,
-			service.UserOrgURL,
-			service.PreferredDomain,
+			config.Provider,
+			config.ClientID,
+			config.ClientSecret,
+			config.AuthURL,
+			config.TokenURL,
+			config.LogoutURL,
+			config.RedirectURL,
+			config.UserInfoURL,
+			config.UserTeamURL,
+			config.UserOrgURL,
+			config.PreferredDomain,
 		})
 		sacfgs = append(sacfgs, [][]string{
-			service.RedirectURLs,
-			service.Scopes,
+			config.RedirectURLs,
+			config.Scopes,
 		})
-	}
+	})
 
 	tests := []struct {
 		name string

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -78,10 +78,10 @@ type oauthConfig struct {
 	CodeChallengeMethod string   `mapstructure:"code_challenge_method" envconfig:"code_challenge_method"`
 }
 
-func configureOauth() error {
-	// OAuth defaults and client configuration
-	return UnmarshalKey("oauth", &GenOAuth)
-
+func ConfigureOauth() {
+	if err := UnmarshalKey("oauth", &GenOAuth); err == nil {
+		setProviderDefaults()
+	}
 }
 
 func oauthBasicTest() error {

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -20,7 +20,6 @@ import (
 
 	// "github.com/vouch/vouch-proxy/pkg/structs"
 	"github.com/vouch/vouch-proxy/pkg/cfg"
-	"github.com/vouch/vouch-proxy/pkg/domains"
 	"go.uber.org/zap"
 )
 
@@ -41,7 +40,7 @@ func SetCookie(w http.ResponseWriter, r *http.Request, val string) {
 func setCookie(w http.ResponseWriter, r *http.Request, val string, maxAge int) {
 	cookieName := cfg.Cfg.Cookie.Name
 	// foreach domain
-	domain := domains.Matches(r.Host)
+	domain := cfg.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
 	if cfg.Cfg.Cookie.Domain != "" {
 		domain = cfg.Cfg.Cookie.Domain
@@ -150,7 +149,7 @@ func Cookie(r *http.Request) (string, error) {
 // ClearCookie get rid of the existing cookie
 func ClearCookie(w http.ResponseWriter, r *http.Request) {
 	cookies := r.Cookies()
-	domain := domains.Matches(r.Host)
+	domain := cfg.Matches(r.Host)
 	// Allow overriding the cookie domain in the config file
 	if cfg.Cfg.Cookie.Domain != "" {
 		domain = cfg.Cfg.Cookie.Domain

--- a/pkg/cookie/cookie_test.go
+++ b/pkg/cookie/cookie_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	cfg.InitForTestPurposes()
+	cfg.InitForTestPurposes(nil)
 	Configure()
 }
 

--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -23,7 +23,7 @@ var log *zap.SugaredLogger
 // Configure see main.go configure()
 func Configure() {
 	log = cfg.Logging.Logger
-	sort.Sort(ByLengthDesc(cfg.Cfg.Domains))
+	sort.Sort(ByUri(cfg.Cfg.Domains))
 }
 
 // IsUnderManagement check if an email is under vouch-managed domain
@@ -43,16 +43,16 @@ func IsUnderManagement(email string) bool {
 
 // ByLengthDesc sort from
 // https://play.golang.org/p/N6GbEgBffd
-type ByLengthDesc []string
+type ByUri cfg.DomainsOptions
 
-func (s ByLengthDesc) Len() int {
+func (s ByUri) Len() int {
 	return len(s)
 }
-func (s ByLengthDesc) Swap(i, j int) {
+func (s ByUri) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// this differs by offing the longest first
-func (s ByLengthDesc) Less(i, j int) bool {
-	return len(s[j]) < len(s[i])
+// this differs by sorting by Uri
+func (s ByUri) Less(i, j int) bool {
+	return s[j].Uri < s[i].Uri
 }

--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -26,27 +26,6 @@ func Configure() {
 	sort.Sort(ByLengthDesc(cfg.Cfg.Domains))
 }
 
-// Matches returns one of the domains we're configured for
-func Matches(s string) string {
-	if strings.Contains(s, ":") {
-		// then we have a port and we just want to check the host
-		split := strings.Split(s, ":")
-		log.Debugf("removing port from %s to test domain %s", s, split[0])
-		s = split[0]
-	}
-
-	if len(cfg.Cfg.Domains) > 0 {
-		for i, v := range cfg.Cfg.Domains {
-			if s == v || strings.HasSuffix(s, "."+v) {
-				log.Debugf("domain %s matched array value at [%d]=%v", s, i, v)
-				return v
-			}
-		}
-		log.Warnf("domain %s not found in any domains %v", s, cfg.Cfg.Domains)
-	}
-	return ""
-}
-
 // IsUnderManagement check if an email is under vouch-managed domain
 func IsUnderManagement(email string) bool {
 	split := strings.Split(email, "@")
@@ -55,7 +34,7 @@ func IsUnderManagement(email string) bool {
 		return false
 	}
 
-	match := Matches(split[1])
+	match := cfg.Matches(split[1])
 	if match != "" {
 		return true
 	}

--- a/pkg/domains/domains.go
+++ b/pkg/domains/domains.go
@@ -23,7 +23,7 @@ var log *zap.SugaredLogger
 // Configure see main.go configure()
 func Configure() {
 	log = cfg.Logging.Logger
-	sort.Sort(ByUri(cfg.Cfg.Domains))
+	sort.Sort(ByUriLengthDesc(cfg.Cfg.Domains))
 }
 
 // IsUnderManagement check if an email is under vouch-managed domain
@@ -43,16 +43,16 @@ func IsUnderManagement(email string) bool {
 
 // ByLengthDesc sort from
 // https://play.golang.org/p/N6GbEgBffd
-type ByUri cfg.DomainsOptions
+type ByUriLengthDesc cfg.DomainsOptions
 
-func (s ByUri) Len() int {
+func (s ByUriLengthDesc) Len() int {
 	return len(s)
 }
-func (s ByUri) Swap(i, j int) {
+func (s ByUriLengthDesc) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-// this differs by sorting by Uri
-func (s ByUri) Less(i, j int) bool {
-	return s[j].Uri < s[i].Uri
+// this differs by offing the longest first
+func (s ByUriLengthDesc) Less(i, j int) bool {
+	return len(s[j].Uri) < len(s[i].Uri)
 }

--- a/pkg/domains/domains_test.go
+++ b/pkg/domains/domains_test.go
@@ -18,8 +18,12 @@ import (
 )
 
 func init() {
-	cfg.InitForTestPurposes()
-	cfg.Cfg.Domains = []string{"vouch.github.io", "sub.test.mydomain.com", "test.mydomain.com"}
+	domains := []cfg.DomainOptions{
+		{Uri: "vouch.github.io", ServiceId: "test_service"},
+		{Uri: "sub.test.mydomain.com", ServiceId: "test_service"},
+		{Uri: "test.mydomain.com", ServiceId: "test_service"},
+	}
+	cfg.InitForTestPurposes(&domains)
 	Configure()
 }
 

--- a/pkg/domains/domains_test.go
+++ b/pkg/domains/domains_test.go
@@ -37,16 +37,16 @@ func TestIsUnderManagement(t *testing.T) {
 
 func TestMatches(t *testing.T) {
 	// Full email should not be accepted
-	assert.Equal(t, "", Matches("test@vouch.github.io"))
+	assert.Equal(t, "", cfg.Matches("test@vouch.github.io"))
 
-	assert.Equal(t, "vouch.github.io", Matches("vouch.github.io"))
-	assert.Equal(t, "vouch.github.io", Matches("sub.vouch.github.io"))
-	assert.Equal(t, "", Matches("a-different-vouch.github.io"))
+	assert.Equal(t, "vouch.github.io", cfg.Matches("vouch.github.io"))
+	assert.Equal(t, "vouch.github.io", cfg.Matches("sub.vouch.github.io"))
+	assert.Equal(t, "", cfg.Matches("a-different-vouch.github.io"))
 
-	assert.Equal(t, "", Matches("mydomain.com"))
+	assert.Equal(t, "", cfg.Matches("mydomain.com"))
 
-	assert.Equal(t, "test.mydomain.com", Matches("test.mydomain.com"))
-	assert.Equal(t, "sub.test.mydomain.com", Matches("sub.test.mydomain.com"))
-	assert.Equal(t, "sub.test.mydomain.com", Matches("subsub.sub.test.mydomain.com"))
-	assert.Equal(t, "test.mydomain.com", Matches("other.test.mydomain.com"))
+	assert.Equal(t, "test.mydomain.com", cfg.Matches("test.mydomain.com"))
+	assert.Equal(t, "sub.test.mydomain.com", cfg.Matches("sub.test.mydomain.com"))
+	assert.Equal(t, "sub.test.mydomain.com", cfg.Matches("subsub.sub.test.mydomain.com"))
+	assert.Equal(t, "test.mydomain.com", cfg.Matches("other.test.mydomain.com"))
 }

--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -69,7 +69,7 @@ func populateSites() {
 	// if we add fine grain ability (ACL?) to the equation
 	// then we're going to have to add something fancier here
 	for i := 0; i < len(cfg.Cfg.Domains); i++ {
-		Sites = append(Sites, cfg.Cfg.Domains[i])
+		Sites = append(Sites, cfg.Cfg.Domains[i].Uri)
 	}
 }
 

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -45,7 +45,7 @@ var (
 func init() {
 	// log.SetLevel(log.DebugLevel)
 
-	cfg.InitForTestPurposes()
+	cfg.InitForTestPurposes(nil)
 	Configure()
 
 	lc = VouchClaims{
@@ -74,5 +74,5 @@ func TestClaims(t *testing.T) {
 	utsParsed, _ := ParseTokenString(uts)
 	log.Infof("utsParsed: %+v", utsParsed)
 	log.Infof("Sites: %+v", Sites)
-	assert.True(t, SiteInToken(cfg.Cfg.Domains[0], utsParsed))
+	assert.True(t, SiteInToken(cfg.Cfg.Domains[0].Uri, utsParsed))
 }

--- a/pkg/providers/adfs/adfs.go
+++ b/pkg/providers/adfs/adfs.go
@@ -47,20 +47,20 @@ func (Provider) Configure() {
 
 // GetUserInfo provider specific call to get userinfomation
 // More info: https://docs.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-scenarios-for-developers#supported-scenarios
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	code := r.URL.Query().Get("code")
 	log.Debugf("code: %s", code)
 
 	formData := url.Values{}
 	formData.Set("code", code)
 	formData.Set("grant_type", "authorization_code")
-	formData.Set("resource", cfg.GenOAuth.RedirectURL)
-	formData.Set("client_id", cfg.GenOAuth.ClientID)
-	formData.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
-	if cfg.GenOAuth.ClientSecret != "" {
-		formData.Set("client_secret", cfg.GenOAuth.ClientSecret)
+	formData.Set("resource", service.RedirectURL)
+	formData.Set("client_id", service.ClientID)
+	formData.Set("redirect_uri", service.RedirectURL)
+	if service.ClientSecret != "" {
+		formData.Set("client_secret", service.ClientSecret)
 	}
-	req, err := http.NewRequest("POST", cfg.GenOAuth.TokenURL, strings.NewReader(formData.Encode()))
+	req, err := http.NewRequest("POST", service.TokenURL, strings.NewReader(formData.Encode()))
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/azure/azure.go
+++ b/pkg/providers/azure/azure.go
@@ -35,7 +35,7 @@ func (Provider) Configure() {
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	_, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
 	if err != nil {
 		return err

--- a/pkg/providers/azure/azure.go
+++ b/pkg/providers/azure/azure.go
@@ -28,14 +28,16 @@ import (
 type Provider struct{}
 
 var log *zap.SugaredLogger
+var config *cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = configp
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	_, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
 	if err != nil {
 		return err

--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -30,22 +30,24 @@ type Provider struct {
 }
 
 var log *zap.SugaredLogger
+var config *cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = configp
 }
 
 // GetUserInfo github user info, calls github api for org and teams
 // https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/
-func (me Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (me Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, ptoken, err := me.PrepareTokensAndClient(r, ptokens, true)
 	if err != nil {
 		// http.Error(w, err.Error(), http.StatusBadRequest)
 		return err
 	}
 	log.Errorf("ptoken.AccessToken: %s", ptoken.AccessToken)
-	userinfo, err := client.Get(service.UserInfoURL + ptoken.AccessToken)
+	userinfo, err := client.Get(config.UserInfoURL + ptoken.AccessToken)
 	if err != nil {
 		// http.Error(w, err.Error(), http.StatusBadRequest)
 		return err
@@ -99,9 +101,9 @@ func (me Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *s
 				var err error
 				isMember := false
 				if team != "" {
-					isMember, err = getTeamMembershipStateFromGitHub(service, client, user, org, team, ptoken)
+					isMember, err = getTeamMembershipStateFromGitHub(client, user, org, team, ptoken)
 				} else {
-					isMember, err = getOrgMembershipStateFromGitHub(service, client, user, org, ptoken)
+					isMember, err = getOrgMembershipStateFromGitHub(client, user, org, ptoken)
 				}
 				if err != nil {
 					return err
@@ -121,9 +123,9 @@ func (me Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *s
 	return nil
 }
 
-func getOrgMembershipStateFromGitHub(service cfg.OauthConfig, client *http.Client, user *structs.User, orgID string, ptoken *oauth2.Token) (isMember bool, rerr error) {
+func getOrgMembershipStateFromGitHub(client *http.Client, user *structs.User, orgID string, ptoken *oauth2.Token) (isMember bool, rerr error) {
 	replacements := strings.NewReplacer(":org_id", orgID, ":username", user.Username)
-	orgMembershipResp, err := client.Get(replacements.Replace(service.UserOrgURL) + ptoken.AccessToken)
+	orgMembershipResp, err := client.Get(replacements.Replace(config.UserOrgURL) + ptoken.AccessToken)
 	if err != nil {
 		log.Error(err)
 		return false, err
@@ -149,9 +151,9 @@ func getOrgMembershipStateFromGitHub(service cfg.OauthConfig, client *http.Clien
 	}
 }
 
-func getTeamMembershipStateFromGitHub(service cfg.OauthConfig, client *http.Client, user *structs.User, orgID string, team string, ptoken *oauth2.Token) (isMember bool, rerr error) {
+func getTeamMembershipStateFromGitHub(client *http.Client, user *structs.User, orgID string, team string, ptoken *oauth2.Token) (isMember bool, rerr error) {
 	replacements := strings.NewReplacer(":org_id", orgID, ":team_slug", team, ":username", user.Username)
-	membershipStateResp, err := client.Get(replacements.Replace(service.UserTeamURL) + ptoken.AccessToken)
+	membershipStateResp, err := client.Get(replacements.Replace(config.UserTeamURL) + ptoken.AccessToken)
 	if err != nil {
 		log.Error(err)
 		return false, err

--- a/pkg/providers/github/github_test.go
+++ b/pkg/providers/github/github_test.go
@@ -84,14 +84,17 @@ var (
 	client          = &http.Client{Transport: &Transport{}}
 )
 
-func setUp() {
+func setUp(t *testing.T) {
 	log = cfg.Logging.Logger
-	cfg.InitForTestPurposesWithProvider("github")
+	domainOptions := cfg.DomainOptions{
+		Uri:       "domain1",
+		ServiceId: "test_service",
+	}
+	cfg.InitForTestPurposesWithProvider("github", &[]cfg.DomainOptions{domainOptions})
 
 	cfg.Cfg.AllowAllUsers = false
 	cfg.Cfg.WhiteList = make([]string, 0)
 	cfg.Cfg.TeamWhiteList = make([]string, 0)
-	cfg.Cfg.Domains = []string{"domain1"}
 
 	domains.Configure()
 
@@ -102,40 +105,44 @@ func setUp() {
 }
 
 func TestGetTeamMembershipStateFromGitHubActive(t *testing.T) {
-	setUp()
+	setUp(t)
 	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"active\"}"))
 
-	isMember, err := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+	service := cfg.GenOAuth.Services[0]
+	isMember, err := getTeamMembershipStateFromGitHub(service, client, user, "org1", "team1", token)
 
 	assert.Nil(t, err)
 	assert.True(t, isMember)
 }
 
 func TestGetTeamMembershipStateFromGitHubInactive(t *testing.T) {
-	setUp()
+	setUp(t)
 	mockResponse(regexMatcher(".*"), http.StatusOK, map[string]string{}, []byte("{\"state\": \"inactive\"}"))
 
-	isMember, err := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+	service := cfg.GenOAuth.Services[0]
+	isMember, err := getTeamMembershipStateFromGitHub(service, client, user, "org1", "team1", token)
 
 	assert.Nil(t, err)
 	assert.False(t, isMember)
 }
 
 func TestGetTeamMembershipStateFromGitHubNotAMember(t *testing.T) {
-	setUp()
+	setUp(t)
 	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
 
-	isMember, err := getTeamMembershipStateFromGitHub(client, user, "org1", "team1", token)
+	service := cfg.GenOAuth.Services[0]
+	isMember, err := getTeamMembershipStateFromGitHub(service, client, user, "org1", "team1", token)
 
 	assert.Nil(t, err)
 	assert.False(t, isMember)
 }
 
 func TestGetOrgMembershipStateFromGitHubNotFound(t *testing.T) {
-	setUp()
+	setUp(t)
 	mockResponse(regexMatcher(".*"), http.StatusNotFound, map[string]string{}, []byte(""))
 
-	isMember, err := getOrgMembershipStateFromGitHub(client, user, "myorg", token)
+	service := cfg.GenOAuth.Services[0]
+	isMember, err := getOrgMembershipStateFromGitHub(service, client, user, "myorg", token)
 
 	assert.Nil(t, err)
 	assert.False(t, isMember)
@@ -145,13 +152,14 @@ func TestGetOrgMembershipStateFromGitHubNotFound(t *testing.T) {
 }
 
 func TestGetOrgMembershipStateFromGitHubNoOrgAccess(t *testing.T) {
-	setUp()
+	setUp(t)
 	location := "https://api.github.com/orgs/myorg/public_members/" + user.Username
 
 	mockResponse(regexMatcher(".*orgs/myorg/members.*"), http.StatusFound, map[string]string{"Location": location}, []byte(""))
 	mockResponse(regexMatcher(".*orgs/myorg/public_members.*"), http.StatusNoContent, map[string]string{}, []byte(""))
 
-	isMember, err := getOrgMembershipStateFromGitHub(client, user, "myorg", token)
+	service := cfg.GenOAuth.Services[0]
+	isMember, err := getOrgMembershipStateFromGitHub(service, client, user, "myorg", token)
 
 	assert.Nil(t, err)
 	assert.True(t, isMember)
@@ -164,7 +172,7 @@ func TestGetOrgMembershipStateFromGitHubNoOrgAccess(t *testing.T) {
 }
 
 func TestGetUserInfo(t *testing.T) {
-	setUp()
+	setUp(t)
 
 	userInfoContent, _ := json.Marshal(structs.GitHubUser{
 		User: structs.User{
@@ -178,7 +186,8 @@ func TestGetUserInfo(t *testing.T) {
 		Login:   "myusername",
 		Picture: "avatar-url",
 	})
-	mockResponse(urlEquals(cfg.GenOAuth.UserInfoURL+token.AccessToken), http.StatusOK, map[string]string{}, userInfoContent)
+	service := cfg.GenOAuth.Services[0]
+	mockResponse(urlEquals(service.UserInfoURL+token.AccessToken), http.StatusOK, map[string]string{}, userInfoContent)
 
 	cfg.Cfg.TeamWhiteList = append(cfg.Cfg.TeamWhiteList, "myOtherOrg", "myorg/myteam")
 
@@ -188,7 +197,7 @@ func TestGetUserInfo(t *testing.T) {
 	provider := Provider{PrepareTokensAndClient: func(_ *http.Request, _ *structs.PTokens, _ bool, opts ...oauth2.AuthCodeOption) (*http.Client, *oauth2.Token, error) {
 		return client, token, nil
 	}}
-	err := provider.GetUserInfo(nil, user, &structs.CustomClaims{}, &structs.PTokens{})
+	err := provider.GetUserInfo(service, nil, user, &structs.CustomClaims{}, &structs.PTokens{})
 
 	assert.Nil(t, err)
 	assert.Equal(t, "myusername", user.Username)

--- a/pkg/providers/google/google.go
+++ b/pkg/providers/google/google.go
@@ -33,12 +33,12 @@ func (Provider) Configure() {
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	userinfo, err := client.Get(service.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/google/google.go
+++ b/pkg/providers/google/google.go
@@ -26,19 +26,21 @@ import (
 type Provider struct{}
 
 var log *zap.SugaredLogger
+var config *cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = configp
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(service.UserInfoURL)
+	userinfo, err := client.Get(config.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/homeassistant/homeassistant.go
+++ b/pkg/providers/homeassistant/homeassistant.go
@@ -32,7 +32,7 @@ func (Provider) Configure() {
 
 // GetUserInfo provider specific call to get userinfomation
 // More info: https://developers.home-assistant.io/docs/en/auth_api.html
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	_, providerToken, err := common.PrepareTokensAndClient(r, ptokens, false, opts...)
 	if err != nil {
 		return err

--- a/pkg/providers/homeassistant/homeassistant.go
+++ b/pkg/providers/homeassistant/homeassistant.go
@@ -24,15 +24,17 @@ import (
 type Provider struct{}
 
 var log *zap.SugaredLogger
+var config *cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = configp
 }
 
 // GetUserInfo provider specific call to get userinfomation
 // More info: https://developers.home-assistant.io/docs/en/auth_api.html
-func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	_, providerToken, err := common.PrepareTokensAndClient(r, ptokens, false, opts...)
 	if err != nil {
 		return err

--- a/pkg/providers/indieauth/indieauth.go
+++ b/pkg/providers/indieauth/indieauth.go
@@ -35,7 +35,7 @@ func (Provider) Configure() {
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	// indieauth sends the "me" setting in json back to the callback, so just pluck it from the callback
 	code := r.URL.Query().Get("code")
 	log.Errorf("ptoken.AccessToken: %s", code)
@@ -49,25 +49,25 @@ func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *s
 	if _, err = fw.Write([]byte(code)); err != nil {
 		return err
 	}
-	// v.Set("redirect_uri", cfg.GenOAuth.RedirectURL)
+	// v.Set("redirect_uri", cfg.service.RedirectURL)
 	if fw, err = w.CreateFormField("redirect_uri"); err != nil {
 		return err
 	}
-	if _, err = fw.Write([]byte(cfg.GenOAuth.RedirectURL)); err != nil {
+	if _, err = fw.Write([]byte(service.RedirectURL)); err != nil {
 		return err
 	}
-	// v.Set("client_id", cfg.GenOAuth.ClientID)
+	// v.Set("client_id", cfg.service.ClientID)
 	if fw, err = w.CreateFormField("client_id"); err != nil {
 		return err
 	}
-	if _, err = fw.Write([]byte(cfg.GenOAuth.ClientID)); err != nil {
+	if _, err = fw.Write([]byte(service.ClientID)); err != nil {
 		return err
 	}
 	if err = w.Close(); err != nil {
 		log.Error("error closing writer.")
 	}
 
-	req, err := http.NewRequest("POST", cfg.GenOAuth.AuthURL, &b)
+	req, err := http.NewRequest("POST", service.AuthURL, &b)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *s
 	req.Header.Set("Accept", "application/json")
 
 	// v := url.Values{}
-	// userinfo, err := client.PostForm(cfg.GenOAuth.UserInfoURL, v)
+	// userinfo, err := client.PostForm(cfg.service.UserInfoURL, v)
 
 	client := &http.Client{}
 	userinfo, err := client.Do(req)

--- a/pkg/providers/nextcloud/nextcloud.go
+++ b/pkg/providers/nextcloud/nextcloud.go
@@ -33,12 +33,12 @@ func (Provider) Configure() {
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, true)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	userinfo, err := client.Get(service.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/nextcloud/nextcloud.go
+++ b/pkg/providers/nextcloud/nextcloud.go
@@ -26,19 +26,21 @@ import (
 type Provider struct{}
 
 var log *zap.SugaredLogger
+var config *cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = configp
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, true)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(service.UserInfoURL)
+	userinfo, err := client.Get(config.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/openid/openid.go
+++ b/pkg/providers/openid/openid.go
@@ -33,12 +33,12 @@ func (Provider) Configure() {
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	userinfo, err := client.Get(service.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/openid/openid.go
+++ b/pkg/providers/openid/openid.go
@@ -26,19 +26,21 @@ import (
 type Provider struct{}
 
 var log *zap.SugaredLogger
+var config *cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = configp
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(service.UserInfoURL)
+	userinfo, err := client.Get(config.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/openstax/openstax.go
+++ b/pkg/providers/openstax/openstax.go
@@ -26,19 +26,21 @@ import (
 type Provider struct{}
 
 var log *zap.SugaredLogger
+var config cfg.OauthConfig
 
 // Configure see main.go configure()
-func (Provider) Configure() {
+func (Provider) Configure(configp *cfg.OauthConfig) {
 	log = cfg.Logging.Logger
+	config = *configp
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, false, opts...)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(service.UserInfoURL)
+	userinfo, err := client.Get(config.UserInfoURL)
 	if err != nil {
 		return err
 	}

--- a/pkg/providers/openstax/openstax.go
+++ b/pkg/providers/openstax/openstax.go
@@ -33,12 +33,12 @@ func (Provider) Configure() {
 }
 
 // GetUserInfo provider specific call to get userinfomation
-func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+func (Provider) GetUserInfo(service cfg.OauthConfig, r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
 	client, _, err := common.PrepareTokensAndClient(r, ptokens, false, opts...)
 	if err != nil {
 		return err
 	}
-	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	userinfo, err := client.Get(service.UserInfoURL)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I did a quick hack regarding #302:

- multiple oauth configurations (services) can be provided
- each domain need to specify its desired service. if no domain is specified, the first service is used.


An old config needs to changed changed from 
```
vouch:
  domains:
    - example1.tld
    - example2.tld
oauth:
  provider: oidc
```
to the following config

```
vouch:
  domains:
    - uri: example1.tld
      service: oidc_service
    - uri: example2.tld
      service: oidc_service
oauth:
  services:
    id: oidc_service
    provider: oidc
```

Domains can be specified using the environment using
``` VOUCH_DOMAINS=uri=example1.tld;service=oidc_service,uri=example2.tld;service=oidc_service. ```

I'm not sure what to do with the env configuration for oauth.
 - Allow only one oauth service in env (which updates one service by id or all services)
 - Use syntax like Domains.
 - Loop through env vars manually with the following format
```
OAUTH_oidcService_Provider= oidc
OAUTH_oidcService_ClientSecret = secret
```