### PR TITLE
add support for multiple login states in different tabs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN ./do.sh install
 FROM scratch
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY templates/ templates/
-COPY .defaults.yml .defaults.yml 
+COPY templates /templates
+COPY .defaults.yml /.defaults.yml 
 # see note for /static in main.go
 COPY static /static
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,8 +20,8 @@ RUN ./do.sh install
 FROM alpine:latest
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY templates/ templates/
-COPY .defaults.yml .defaults.yml 
+COPY templates /templates
+COPY .defaults.yml /.defaults.yml 
 # see note for /static in main.go
 COPY static /static
 COPY do.sh /do.sh

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -52,6 +52,11 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	// set the state variable in the session
 	session.Values["state"] = state
+
+	// set the path for the session cookie to only send the correct cookie to /auth/{state}/
+	// must have a trailing slash. Otherwise, it is send to all endpoints that _start_ with the cookie path.
+	session.Options.Path = fmt.Sprintf("/auth/%s/", state)
+
 	log.Debugf("session state set to %s", session.Values["state"])
 
 	// requestedURL comes from nginx in the query string via a 302 redirect

--- a/main.go
+++ b/main.go
@@ -141,6 +141,9 @@ func main() {
 	logoutH := http.HandlerFunc(handlers.LogoutHandler)
 	muxR.HandleFunc("/logout", timelog.TimeLog(logoutH))
 
+	authStateH := http.HandlerFunc(handlers.AuthStateHandler)
+	muxR.HandleFunc("/auth/{state}/", timelog.TimeLog(authStateH))
+
 	callH := http.HandlerFunc(handlers.CallbackHandler)
 	muxR.HandleFunc("/auth", timelog.TimeLog(callH))
 


### PR DESCRIPTION
This addresses the issue with an invalid session state when opening multiple login pages in different tabs. As the state is stored in a cookie, the latest call to /login overrides the state of the previous login tabs. When logging in to those old tabs, the state in the URL no longer matches the state in the cookie.
The problem is described in detail in issue #349 

Changes:
The session cookie that contains the state now has its path attribute set to /auth/[state]/.
-> One cookie is set per opened login page, each with a different path.
/auth redirects the user to this new endpoint, which will only receive the session cookie that was set with this specific state. /auth/[state]/ will then perform the known authentication that was formerly done by /auth.

The cookies are still cleared after 5 minutes, so even though multiple cookies could be set, this should not lead to too many cookies long-term.

Things I am unsure about:
* is this new setup (with /auth doing essentially nothing else than a redirect and /auth/[state] doing the authentication) okay?
* does this lead to any vulnerabilities? I couldn't think of any, but am not an security expert either

Things that still need to be done after the source code is reviewed:
* Adjust Readme
* Maybe write some tests?


~Oh and I only tested with Firefox. I would hope that cookie behavior does not differ in different browsers, but should check before merging.~

Tested on MacOS (Safari, Firefox, Chrome), iOS (Safari) and Windows (Firefox, Chrome, Internet Explorer, Edge)