### PR TITLE
Fix cookie.maxAge in config example

### DIFF
--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -92,8 +92,10 @@ vouch:
 
     # httpOnly: true # VOUCH_COOKIE_HTTPONLY
 
-    # Set cookie maxAge to 0 to delete the cookie every time the browser is closed. - VOUCH_COOKIE_MAXAGE
-    maxAge: 14400
+    # Number of minutes until session cookie expires - VOUCH_COOKIE_MAXAGE
+    # Set cookie maxAge to 0 to delete the cookie every time the browser is closed.
+    # Must not longer than jwt.maxAge
+    maxAge: 240
 
     # Set SameSite attribute to restrict browser behaviour wrt sending the cookie along with cross-site requests. - VOUCH_COOKIE_SAMESITE
     # Possible attribute values lax, strict, none.


### PR DESCRIPTION
If the value for cookie.maxAge is larger than for jwt.maxAge the value is set to jwt.maxAge.
This has been implemented in #103 but the config example was a bit unclear.