### PR TITLE
use the error template for Error 401

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -33,7 +33,7 @@ func CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	errorIDP := r.URL.Query().Get("error")
 	if errorIDP != "" {
 		errorDescription := r.URL.Query().Get("error_description")
-		responses.Error401(w, r, fmt.Errorf("/auth Error from IdP: %s - %s", errorIDP, errorDescription))
+		responses.Error401HTTP(w, r, fmt.Errorf("/auth Error from IdP: %s - %s", errorIDP, errorDescription))
 		return
 	}
 


### PR DESCRIPTION
Previously this was plain text. Passing it through the existing
error templates allows administrators of vouch-proxy to customize
the output in the case of a auth failure.

Fixes: #338 