### PR TITLE
embed the templates and static files into the vouch binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY templates /templates
 COPY .defaults.yml /.defaults.yml 
-# see note for /static in main.go
-COPY static /static
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN ./do.sh install
 FROM scratch
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY templates /templates
 COPY .defaults.yml /.defaults.yml 
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 EXPOSE 9090

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -19,8 +19,6 @@ ENV VOUCH_ROOT=/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY templates /templates
 COPY .defaults.yml /.defaults.yml 
-# see note for /static in main.go
-COPY static /static
 
 #  do.sh requires bash
 RUN apk add --no-cache bash

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,7 +17,6 @@ FROM alpine:latest
 LABEL maintainer="vouch@bnf.net"
 ENV VOUCH_ROOT=/
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY templates /templates
 COPY .defaults.yml /.defaults.yml 
 
 #  do.sh requires bash

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -40,7 +40,8 @@ func setUp(configFile string) {
 	domains.Configure()
 	jwtmanager.Configure()
 	cookie.Configure()
-	responses.Configure()
+	var templatesFs = os.DirFS(os.Getenv("VOUCH_ROOT"))
+	responses.Configure(templatesFs)
 
 }
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -41,7 +41,8 @@ func setUp(configFile string) {
 	jwtmanager.Configure()
 	cookie.Configure()
 	var templatesFs = os.DirFS(os.Getenv("VOUCH_ROOT"))
-	responses.Configure(templatesFs)
+	responses.Configure()
+	responses.LoadTemplates(templatesFs)
 
 }
 

--- a/main.go
+++ b/main.go
@@ -113,7 +113,8 @@ func configure() {
 	domains.Configure()
 	jwtmanager.Configure()
 	cookie.Configure()
-	responses.Configure(templatesFs)
+	responses.Configure()
+	responses.LoadTemplates(templatesFs)
 	handlers.Configure()
 	timelog.Configure()
 }

--- a/main.go
+++ b/main.go
@@ -70,6 +70,9 @@ var (
 //go:embed static
 var staticFs embed.FS
 
+//go:embed templates
+var templatesFs embed.FS
+
 // fwdToZapWriter allows us to use the zap.Logger as our http.Server ErrorLog
 // see https://stackoverflow.com/questions/52294334/net-http-set-custom-logger
 type fwdToZapWriter struct {
@@ -110,7 +113,7 @@ func configure() {
 	domains.Configure()
 	jwtmanager.Configure()
 	cookie.Configure()
-	responses.Configure()
+	responses.Configure(templatesFs)
 	handlers.Configure()
 	timelog.Configure()
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -104,7 +104,7 @@ var (
 	// Branding that's our name
 	Branding = branding{"vouch", "VOUCH", "Vouch", "Vouch Proxy", "https://github.com/vouch/vouch-proxy"}
 
-	// RootDir is where Vouch Proxy looks for ./config/config.yml, ./data, ./static and ./templates
+	// RootDir is where Vouch Proxy looks for ./config/config.yml, ./data and ./templates
 	RootDir string
 
 	secretFile string

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -104,7 +104,7 @@ var (
 	// Branding that's our name
 	Branding = branding{"vouch", "VOUCH", "Vouch", "Vouch Proxy", "https://github.com/vouch/vouch-proxy"}
 
-	// RootDir is where Vouch Proxy looks for ./config/config.yml, ./data and ./templates
+	// RootDir is where Vouch Proxy looks for ./config/config.yml and ./data
 	RootDir string
 
 	secretFile string

--- a/pkg/responses/responses.go
+++ b/pkg/responses/responses.go
@@ -13,8 +13,8 @@ package responses
 import (
 	"errors"
 	"html/template"
+	"io/fs"
 	"net/http"
-	"path/filepath"
 
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/cookie"
@@ -39,12 +39,12 @@ var (
 )
 
 // Configure see main.go configure()
-func Configure() {
+func Configure(templatesFs fs.FS) {
 	log = cfg.Logging.Logger
 	fastlog = cfg.Logging.FastLogger
 
-	log.Debugf("responses.Configure() attempting to parse templates with cfg.RootDir: %s", cfg.RootDir)
-	indexTemplate = template.Must(template.ParseFiles(filepath.Join(cfg.RootDir, "templates/index.tmpl")))
+	log.Debugf("responses.Configure() attempting to parse embedded templates")
+	indexTemplate = template.Must(template.ParseFS(templatesFs, "templates/index.tmpl"))
 
 }
 

--- a/pkg/responses/responses.go
+++ b/pkg/responses/responses.go
@@ -39,13 +39,14 @@ var (
 )
 
 // Configure see main.go configure()
-func Configure(templatesFs fs.FS) {
+func Configure() {
 	log = cfg.Logging.Logger
 	fastlog = cfg.Logging.FastLogger
+}
 
+func LoadTemplates(templatesFs fs.FS) {
 	log.Debugf("responses.Configure() attempting to parse embedded templates")
 	indexTemplate = template.Must(template.ParseFS(templatesFs, "templates/index.tmpl"))
-
 }
 
 // RenderIndex render the response as an HTML page, mostly used in testing


### PR DESCRIPTION
uses `//go:embed` introduced with Go 1.16
https://golang.org/pkg/embed/

commits can be reviewed one by one.