### PR TITLE
introduce explicit cfg.StateDir

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -109,6 +109,8 @@ var (
 
 	// RootDir is where Vouch Proxy looks for ./config/config.yml and ./data
 	RootDir string
+	// StateDir is where Vouch Proxy writes its state or files
+	StateDir string
 
 	secretFile string
 
@@ -175,7 +177,8 @@ func Configure() {
 	Logging.configureFromCmdline()
 
 	setRootDir()
-	secretFile = filepath.Join(RootDir, "config/secret")
+	setStateDir()
+	secretFile = filepath.Join(StateDir, "secret")
 
 	// bail if we're testing
 	if flag.Lookup("test.v") != nil {
@@ -259,6 +262,16 @@ func setRootDir() {
 			log.Panic(errEx)
 		}
 		RootDir = filepath.Dir(ex)
+	}
+}
+
+func setStateDir() {
+	// use systemd provided StateDirectory or default to $RootDir/config
+	if os.Getenv("STATE_DIRECTORY") != "" {
+		StateDir = strings.Split(os.Getenv("STATE_DIRECTORY"), ":")[0]
+		log.Warnf("set cfg.StateDir from STATE_DIRECTORY env var: %s", StateDir)
+	} else {
+		StateDir = filepath.Join(RootDir, "config")
 	}
 }
 


### PR DESCRIPTION
introduce an explicit cfg.StateDir, which, for now, is only used by the cfg.secretFile, which is $StateDir/secret

cfg.StateDir is initialized by the environment variable STATE_DIRECTORY
compatible with what's provided by systemd (ie. the string is split on
":" and the first item is used).

when STATE_DIRECTORY is not provided, cfg.StateDir is set to $RootDir/config
to preserve the previous behavior (secretFile was
$RootDir/config/secret)