### PR TITLE
Add support for the ClaimsParameter to support Twitch OIDC as IdP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
 
+- add support for [the "claims" Request Parameter](https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter) to support Twitch OIDC as IdP
+- add [Twitch OIDC example](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_twitch)
+
 ## v0.32.0
 
 - [slack oidc example](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_slack) and [slack app manifest](https://github.com/vouch/vouch-proxy/blob/master/examples/slack/vouch-slack-oidc-app-manifest.yml)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ An SSO solution for Nginx using the [auth_request](http://nginx.org/en/docs/http
 
 Vouch Proxy supports many OAuth and OIDC login providers and can enforce authentication to...
 
-- Google
-- [GitHub](https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/about-authorization-options-for-oauth-apps/)
-- GitHub Enterprise
+- [Google](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_google)
+- [GitHub](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_github)
+- [GitHub Enterprise](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_github_enterprise)
 - [IndieAuth](https://indieauth.spec.indieweb.org/)
 - [Okta](https://developer.okta.com/blog/2018/08/28/nginx-auth-request)
 - [Slack](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_slack)
@@ -20,6 +20,7 @@ Vouch Proxy supports many OAuth and OIDC login providers and can enforce authent
 - [Azure AD](https://github.com/vouch/vouch-proxy/issues/290)
 - [Alibaba / Aliyun iDaas](https://github.com/vouch/vouch-proxy/issues/344)
 - [AWS Cognito](https://github.com/vouch/vouch-proxy/issues/105)
+- [Twitch](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_twitch)
 - [Discord](https://github.com/eltariel/foundry-docker-nginx-vouch)
 - [SecureAuth](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_secureauth)
 - [Gitea](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_gitea)
@@ -32,7 +33,7 @@ Vouch Proxy supports many OAuth and OIDC login providers and can enforce authent
 
 Please do let us know when you have deployed Vouch Proxy with your preffered IdP or library so we can update the list.
 
-If Vouch is running on the same host as the Nginx reverse proxy the response time from the `/validate` endpoint to Nginx should be less than 1ms
+If Vouch is running on the same host as the Nginx reverse proxy the response time from the `/validate` endpoint to Nginx should be **less than 1ms**.
 
 ---
 
@@ -40,8 +41,10 @@ If Vouch is running on the same host as the Nginx reverse proxy the response tim
 
 - [What Vouch Proxy Does...](#what-vouch-proxy-does)
 - [Installation and Configuration](#installation-and-configuration)
-- [Configuring Vouch Proxy using Environmental Variables](#configuring-vouch-proxy-using-environmental-variables)
-- [More advanced configurations](#more-advanced-configurations)
+  - [Vouch Proxy "in a path"](#vouch-proxy-in-a-path)
+  - [Additional Nginx Configurations](#Additional Nginx Configurations)
+  - [Configuration via Environmental Variables](#configuring-via-environmental-variables)
+- [Tips, Tricks and Advanced Configurations](#tips-tricks-and-advanced-configurations)
   - [Scopes and Claims](#scopes-and-claims)
 - [Running from Docker](#running-from-docker)
 - [Kubernetes Nginx Ingress](#kubernetes-nginx-ingress)
@@ -225,9 +228,9 @@ server {
 
 Additional Nginx configurations can be found in the [examples](https://github.com/vouch/vouch-proxy/tree/master/examples) directory.
 
-## Configuring Vouch Proxy using Environmental Variables
+### Configuring via Environmental Variables
 
-Here's a minimal setup using Google OAuth...
+Here's a minimal setup using Google's OAuth...
 
 ```bash
 VOUCH_DOMAINS=yourdomain.com \
@@ -244,7 +247,7 @@ All lists with multiple values must be comma separated: `VOUCH_DOMAINS="yourdoma
 
 The variable `VOUCH_CONFIG` can be used to set an alternate location for the configuration file. `VOUCH_ROOT` can be used to set an alternate root directory for Vouch Proxy to look for support files.
 
-## More advanced configurations
+## Tips, Ticks and Advanced Configurations
 
 All Vouch Proxy configuration items are documented in [config/config.yml_example](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example)
 
@@ -438,7 +441,7 @@ TLDR:
 
 - set `vouch.testing: true`
 - set `vouch.logLevel: debug`
-- conduct a full round trip of `./vouch-proxy` capturing the output..
+- conduct two full round trips of `./vouch-proxy` capturing the output..
   - VP startup
   - `/validate`
   - `/login` - even if the error is here
@@ -465,19 +468,22 @@ docker run --name vouch_proxy -v $PWD/config:/config -v $PWD/certs:/certs -it --
 
 ### Contributing to Vouch Proxy by submitting a Pull Request
 
-I really love Vouch Proxy! I wish it did XXXX...
+**_I really love Vouch Proxy! I wish it did XXXX..._**
 
-Please make a proposal before you spend your time and our time integrating a new feature.
+That's really wonderful and contributions are greatly appreciated. However, please search through the existing issues, both open and closed, to look for any prior work or conversation. Then please make a proposal before we all spend valuable time considering and integrating a new feature.
 
 Code contributions should..
 
+- generally be discussed beforehand in a GitHub issue
 - include unit tests and in some cases end-to-end tests
-- include an entry at the top of CHANGELOG.md in the **Unreleased** section
 - be formatted with `go fmt`, checked with `go vet` and other common go tools
+- accomodate configuration via `config.yml` as well as `ENVIRONMENT_VARIABLEs`.
 - not break existing setups without a clear reason (usually security related)
-- and generally be discussed beforehand in a GitHub issue
+- include an entry at the top of CHANGELOG.md in the **Unreleased** section
 
 For larger contributions or code related to a platform that we don't currently support we will ask you to commit to supporting the feature for an agreed upon period. Invariably someone will pop up here with a question and we want to be able to support these requests.
+
+**Thank you to all of the contributors that have provided their time and effort and thought to improving VP.**
 
 ## Advanced Authorization Using OpenResty
 

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -21,7 +21,8 @@ vouch:
   port: 9090       # VOUCH_PORT
 
   # document_root - VOUCH_DOCUMENT_ROOT
-  # see README for "
+  # see README for `Vouch Proxy "in a path"` - https://github.com/vouch/vouch-proxy#vouch-proxy-in-a-path
+  # document_root: vp_in_a_path
 
   # domains - VOUCH_DOMAINS
   # each of these domains must serve the url https://vouch.$domains[0] https://vouch.$domains[1] ...
@@ -200,6 +201,7 @@ vouch:
 #   preferreddomain:         OAUTH_PREFERREDDOMAIN
 #   callback_urls:           OAUTH_CALLBACK_URLS
 #   scopes:                  OAUTH_SCOPES
+#   claims:                  OAUTH_CLAIMS
 #   code_challenge_method:   OAUTH_CODE_CHALLENGE_METHOD
 #   relying_party_id         OAUTH_RELYING_PARTY_ID
 
@@ -252,8 +254,9 @@ oauth:
     - openid
     - email
     - profile
+  callback_url: http://vouch.yourdomain.com:9090/auth
   # optionally set the "claims" request parameter (see https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter)
-  # resolves issue https://github.com/vouch/vouch-proxy/issues/414
+  # required by Twitch, resolves issue https://github.com/vouch/vouch-proxy/issues/414
   # claims:
     # userinfo:
       # given_name:
@@ -271,7 +274,6 @@ oauth:
       # acr:
         # values:
           # - "urn:mace:incommon:iap:silver"
-  callback_url: http://vouch.yourdomain.com:9090/auth
   # PKCE method if enabled, S256 is currently supported (check https://www.oauth.com/oauth2-servers/pkce/)
   # resolves issue https://github.com/vouch/vouch-proxy/issues/303
   code_challenge_method: S256

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -249,6 +249,25 @@ oauth:
     - openid
     - email
     - profile
+  # optionally set the "claims" request parameter (see https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter)
+  # resolves issue https://github.com/vouch/vouch-proxy/issues/414
+  # claims:
+    # userinfo:
+      # given_name:
+        # essential: true
+      # nickname: null
+      # email:
+        # essential: true
+      # email_verified:
+        # essential: true
+      # picture: null
+      # "http://example.info/claims/groups": null
+    # id_token:
+      # auth_time:
+        # essential: true
+      # acr:
+        # values:
+          # - "urn:mace:incommon:iap:silver"
   callback_url: http://vouch.yourdomain.com:9090/auth
   # PKCE method if enabled, S256 is currently supported (check https://www.oauth.com/oauth2-servers/pkce/)
   # resolves issue https://github.com/vouch/vouch-proxy/issues/303

--- a/config/config.yml_example_twitch
+++ b/config/config.yml_example_twitch
@@ -1,0 +1,43 @@
+
+# vouch config
+# bare minimum to get vouch running with Twitch
+
+vouch:
+  # domains:
+  # valid domains that the jwt cookies can be set into
+  # the callback_urls will be to these domains
+  domains:
+  - yourdomain.com
+  - yourotherdomain.com
+
+  # - OR -
+  # instead of setting specific domains you may prefer to allow all users...
+  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
+  # and set vouch.cookie.domain to the domain you wish to protect
+  # allowAllUsers: true
+
+  cookie:
+    # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com) 
+    secure: false
+    # vouch.cookie.domain must be set when enabling allowAllUsers
+    # domain: yourdomain.com
+
+oauth:
+  # Generic OpenID Connect
+  # including okta
+  provider: oidc
+  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+  auth_url: https://id.twitch.tv/oauth2/authorize
+  token_url: https://id.twitch.tv/oauth2/token
+  user_info_url: https://id.twitch.tv/oauth2/userinfo
+  scopes:
+    - openid
+    - user:read:email
+  claims:
+    userinfo:
+      email:
+        essential: true
+      email_verified:
+        essential: true
+  callback_url: https://vouch.yourdomain.com:9090/auth

--- a/config/config.yml_example_twitch
+++ b/config/config.yml_example_twitch
@@ -18,26 +18,26 @@ vouch:
 
   cookie:
     # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com) 
-    secure: false
+    # secure: false
     # vouch.cookie.domain must be set when enabling allowAllUsers
     # domain: yourdomain.com
 
 oauth:
   # Generic OpenID Connect
-  # including okta
   provider: oidc
   client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
   client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
   auth_url: https://id.twitch.tv/oauth2/authorize
   token_url: https://id.twitch.tv/oauth2/token
   user_info_url: https://id.twitch.tv/oauth2/userinfo
+  callback_url: https://vouch.yourdomain.com/auth
   scopes:
     - openid
     - user:read:email
+  # Twitch uses the claims parameter to configure the information returned via `user_info_url`
   claims:
     userinfo:
       email:
         essential: true
       email_verified:
         essential: true
-  callback_url: https://vouch.yourdomain.com:9090/auth

--- a/config/testing/test_config_oauth_claims.yml
+++ b/config/testing/test_config_oauth_claims.yml
@@ -1,0 +1,48 @@
+vouch:
+  logLevel: debug
+  listen: 0.0.0.0
+  port: 9090
+  domains:
+    - vouch.github.io
+
+  whiteList:
+    - bob@yourdomain.com
+    - alice@yourdomain.com
+    - joe@yourdomain.com
+
+  cookie:
+    name: vouchTestingCookie
+
+  session:
+    name: VouchTestingSession
+
+  jwt:
+    secret: testingsecret
+
+oauth:
+  provider: oidc
+  auth_url: https://oauth2.example.info/authorize
+  token_url: https://oauth2.example.info/token
+  user_info_url: https://oauth2.example.info/userinfo
+  scopes:
+    - openid
+    - email
+    - profile
+  claims:
+    userinfo:
+      given_name:
+        essential: true
+      nickname: null
+      email:
+        essential: true
+      email_verified:
+        essential: true
+      picture: null
+      "http://example.info/claims/groups": null
+    id_token:
+      auth_time:
+        essential: true
+      acr:
+        values:
+          - "urn:mace:incommon:iap:silver"
+  callback_url: https://vouch.yourdomain.com:9090/auth

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -274,7 +274,7 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 		opts = append(opts, oauth2.SetAuthURLParam("code_challenge", session.Values["codeChallenge"].(string)))
 	}
 	if cfg.OAuthopts != nil {
-		opts = append(opts, cfg.OAuthopts)
+		opts = append(opts, cfg.OAuthopts...)
 	}
 	return cfg.OAuthClient.AuthCodeURL(state, opts...)
 }

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -75,7 +75,7 @@ type oauthConfig struct {
 	RedirectURLs   []string `mapstructure:"callback_urls"  envconfig:"callback_urls"`
 	RelyingPartyId string   `mapstructure:"relying_party_id"  envconfig:"relying_party_id"`
 	Scopes         []string `mapstructure:"scopes"`
-	// pointer-to-pointer so that the default value is nil
+	// pointer-to-pointer so that the default uninitialized value is nil
 	Claims              **oauthClaimsConfig `mapstructure:"claims"`
 	UserInfoURL         string              `mapstructure:"user_info_url" envconfig:"user_info_url"`
 	UserTeamURL         string              `mapstructure:"user_team_url" envconfig:"user_team_url"`

--- a/pkg/cfg/oauth_test.go
+++ b/pkg/cfg/oauth_test.go
@@ -11,7 +11,10 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 package cfg
 
 import (
+	"net/url"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_checkCallbackConfig(t *testing.T) {
@@ -32,4 +35,11 @@ func Test_checkCallbackConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_configureOAuthWithClaims(t *testing.T) {
+	setUp("/config/testing/test_config_oauth_claims.yml")
+	authCodeURL, err := url.Parse(OAuthClient.AuthCodeURL("state", OAuthopts...))
+	assert.Nil(t, err)
+	assert.Equal(t, authCodeURL.Query().Get("claims"), `{"userinfo":{"email":{"essential":true},"email_verified":{"essential":true},"given_name":{"essential":true},"http://example.info/claims/groups":null,"nickname":null,"picture":null},"id_token":{"acr":{"values":["urn:mace:incommon:iap:silver"]},"auth_time":{"essential":true}}}`)
 }


### PR DESCRIPTION
@bnfinet I'm done with the implementation. I tested it locally and it worked as expected (I could login, logout and validate sessions issued with Twitch as IdP).

In the end, I opted for a more generic approach and decided to make the claims configuration available to each provider (in the same way the `code_challenge` parameter is handled).

I would like to have your opinion before adding unit tests.

Also, should I update the `CHANGELOG` as suggested in the [README](https://github.com/vouch/vouch-proxy#contributing-to-vouch-proxy-by-submitting-a-pull-request) ?

Happily waiting for your review :)

#414