### PR TITLE
No longer require UserInfoURL to be set for Azure (#417)

### DIFF
--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -137,8 +137,8 @@ func oauthBasicTest() error {
 	case GenOAuth.Provider != Providers.Google && GenOAuth.AuthURL == "":
 		// everyone except IndieAuth and Google has an authURL
 		return errors.New("configuration error: oauth.auth_url not found")
-	case GenOAuth.Provider != Providers.Google && GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.HomeAssistant && GenOAuth.Provider != Providers.ADFS && GenOAuth.UserInfoURL == "":
-		// everyone except IndieAuth, Google and ADFS has an userInfoURL
+	case GenOAuth.Provider != Providers.Google && GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.HomeAssistant && GenOAuth.Provider != Providers.ADFS && GenOAuth.Provider != Providers.Azure && GenOAuth.UserInfoURL == "":
+		// everyone except IndieAuth, Google and ADFS has an userInfoURL, and Azure does not actively use it
 		return errors.New("configuration error: oauth.user_info_url not found")
 	case GenOAuth.CodeChallengeMethod != "" && (GenOAuth.CodeChallengeMethod != "plain" && GenOAuth.CodeChallengeMethod != "S256"):
 		return errors.New("configuration error: oauth.code_challenge_method must be either 'S256' or 'plain'")


### PR DESCRIPTION
As mentioned in #417, it seems that ``oauth.user_info_url`` is not used or required for normal operation in Azure AD.

Exempt it from the check for a valid UserInfoURL.