### PR TITLE
Add proxy_ssl verify statements to the k8s-ingress example, to avoid opening up a MITM vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,14 @@ If you are using kubernetes with [nginx-ingress](https://github.com/kubernetes/i
     nginx.ingress.kubernetes.io/auth-url: https://vouch.yourdomain.com/validate
     nginx.ingress.kubernetes.io/auth-response-headers: X-Vouch-User
     nginx.ingress.kubernetes.io/auth-snippet: |
+      # If your Vouch is using HTTPS and is hosted externally to k8s, you
+      # should uncomment the following values to ensure the SSL cert is
+      # valid. Nginx does not validate SSL certs by default, so it could
+      # be a MITM risk otherwise.
+      # proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+      # proxy_ssl_session_reuse on;
+      # proxy_ssl_verify_depth 2;
+      # proxy_ssl_verify on;
       # these return values are used by the @error401 call
       auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
       auth_request_set $auth_resp_err $upstream_http_x_vouch_err;


### PR DESCRIPTION
The Kubernetes ingress-nginx 'external auth' annotation for apps that want to delegate auth to Vouch, works great. Thanks! 

However, it should be made very clear that k8s' ingress-nginx [does *not* do SSL verification of upstream proxied apps](https://github.com/kubernetes/ingress-nginx/issues/7083). That's partly because even Nginx itself (like Apache), does not do it by default (proxy_ssl_verify is [`off` by default](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ssl_verify)).

So that people don't accidentally open up a MITM by following the example in the README, we could give example configuration that uses the `auth-snippet` annotation to tack on the proxy_ssl stuff, to keep things secure. Everything works fine with these settings, so long as the SSL cert passes validation (as it should, unless you're using a self-signed cert for some reason).

Since some of the values can be configured in different ways (e.g the depth, the path to the CA cert trust store, etc), I thought having them commented out would be a good middle ground.

Cheers!