### PR TITLE
Add missing `Set` and `tableHasKey` functions to Lua auth examples

### DIFF
--- a/examples/OpenResty/lua/group_auth.lua
+++ b/examples/OpenResty/lua/group_auth.lua
@@ -2,6 +2,16 @@
 --     Group Authentication
 --    via X-Vouch-IdP-Groups
 -- ==============================
+-- Function to turn a table with only values into a k=>v table
+function Set (list)
+    local set = {}
+    for _, l in ipairs(list) do set[l] = true end
+    return set
+end
+-- Function to find a key in a table
+function tableHasKey(table,key)
+    return table[key] ~= nil
+end
 -- Validate that a user is in a group
 local authorized_groups = Set {
     "CN=Domain Users,CN=Users,DC=Contoso,DC=com",

--- a/examples/OpenResty/lua/user_auth.lua
+++ b/examples/OpenResty/lua/user_auth.lua
@@ -2,6 +2,16 @@
 --     User Authentication
 --      via X-Vouch-User
 -- ==============================
+-- Function to turn a table with only values into a k=>v table
+function Set (list)
+    local set = {}
+    for _, l in ipairs(list) do set[l] = true end
+    return set
+end
+-- Function to find a key in a table
+function tableHasKey(table,key)
+    return table[key] ~= nil
+end
 -- Validate a user in nginx, instead of vouch
 local authorized_users = Set {
     "my@account.com",


### PR DESCRIPTION
Fix for #284 