### PR TITLE
run as non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
 
-- [run vouch-proxy as non-root user](https://github.com/vouch/vouch-proxy/pull/444)
+## v0.36.0
+
+- [run Docker containers as non-root user](https://github.com/vouch/vouch-proxy/pull/444)
+
+Permissions may need to be adjusted for `/config/secret` and `/config/config.yml` in Docker environemnts. See the [README](https://github.com/vouch/vouch-proxy#running-from-docker)
 
 ## v0.35.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
 
+- [run vouch-proxy as non-root user](https://github.com/vouch/vouch-proxy/pull/444)
+
 ## v0.35.1
 
 - [include DocumentRoot if configured in error pages](https://github.com/vouch/vouch-proxy/pull/439)

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ COPY . .
 # RUN go-wrapper download  # "go get -d -v ./..."
 # RUN ./do.sh build    # see `do.sh` for vouch build details
 # RUN go-wrapper install # "go install -v ./..."
-RUN groupadd -g 1001 vouch && \
-    useradd -m vouch_user --uid=1001 --gid=1001
+ARG UID=1001
+ARG GID=1001
+RUN groupadd -g $GID vouch && \
+    useradd -m vouch_user --uid=$UID --gid=$GID
 
 RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ FROM scratch
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
+
+RUN groupadd -g 1001 vouch && \
+    useradd -m vouch_user --uid=1001 --gid=1001 && \
+    chown vouch_user:vouch /etc/ssl/certs/ca-certificates.crt && \
+    chown vouch_user:vouch /vouch-proxy
+
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]
 HEALTHCHECK --interval=1m --timeout=5s CMD [ "/vouch-proxy", "-healthcheck" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ COPY . .
 # RUN go-wrapper download  # "go get -d -v ./..."
 # RUN ./do.sh build    # see `do.sh` for vouch build details
 # RUN go-wrapper install # "go install -v ./..."
+RUN groupadd -g 1001 vouch && \
+    useradd -m vouch_user --uid=1001 --gid=1001
 
 RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details
@@ -20,12 +22,10 @@ RUN ./do.sh install
 FROM scratch
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 
-RUN groupadd -g 1001 vouch && \
-    useradd -m vouch_user --uid=1001 --gid=1001 && \
-    chown vouch_user:vouch /etc/ssl/certs/ca-certificates.crt && \
-    chown vouch_user:vouch /vouch-proxy
+USER vouch_user
 
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
-# voucher/vouch-proxy
+# quay.io/vouch/vouch-proxy
 # https://github.com/vouch/vouch-proxy
 FROM golang:1.16 AS builder
 
+ARG UID=999
+ARG GID=999
 LABEL maintainer="vouch@bnf.net"
 
 RUN mkdir -p ${GOPATH}/src/github.com/vouch/vouch-proxy
 WORKDIR ${GOPATH}/src/github.com/vouch/vouch-proxy
 
+RUN groupadd -g $GID vouch \
+    && useradd --system vouch --uid=$UID --gid=$GID
+
 COPY . .
 
-# RUN go-wrapper download  # "go get -d -v ./..."
-# RUN ./do.sh build    # see `do.sh` for vouch build details
-# RUN go-wrapper install # "go install -v ./..."
-ARG UID=1001
-ARG GID=1001
-RUN groupadd -g $GID vouch && \
-    useradd -m vouch_user --uid=$UID --gid=$GID
 
 RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details
@@ -25,9 +23,10 @@ FROM scratch
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 
-USER vouch_user
+USER vouch
 
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -23,6 +23,13 @@ RUN apk add --no-cache bash
 COPY do.sh /do.sh
 
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
+
+RUN groupadd -g 1001 vouch && \
+    useradd -m vouch_user --uid=1001 --gid=1001 && \
+    chown vouch_user:vouch /etc/ssl/certs/ca-certificates.crt && \
+    chown vouch_user:vouch /vouch-proxy && \
+    chown vouch_user:vouch /do.sh
+
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]
 HEALTHCHECK --interval=1m --timeout=5s CMD [ "/vouch-proxy", "-healthcheck" ]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,6 +12,8 @@ COPY . .
 RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details
 RUN ./do.sh install
+RUN groupadd -g 1001 vouch && \
+    useradd -m vouch_user --uid=1001 --gid=1001
 
 FROM alpine:latest
 LABEL maintainer="vouch@bnf.net"
@@ -23,12 +25,9 @@ RUN apk add --no-cache bash
 COPY do.sh /do.sh
 
 COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
+COPY --from=builder /etc/passwd /etc/passwd
 
-RUN groupadd -g 1001 vouch && \
-    useradd -m vouch_user --uid=1001 --gid=1001 && \
-    chown vouch_user:vouch /etc/ssl/certs/ca-certificates.crt && \
-    chown vouch_user:vouch /vouch-proxy && \
-    chown vouch_user:vouch /do.sh
+USER vouch_user
 
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,9 @@
-# voucher/vouch-proxy
+# quay.io/vouch/vouch-proxy
 # https://github.com/vouch/vouch-proxy
 FROM golang:1.16 AS builder
 
+ARG UID=999
+ARG GID=999
 LABEL maintainer="vouch@bnf.net"
 
 RUN mkdir -p ${GOPATH}/src/github.com/vouch/vouch-proxy
@@ -13,10 +15,8 @@ RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details
 RUN ./do.sh install
 
-ARG UID=1001
-ARG GID=1001
-RUN groupadd -g $GID vouch && \
-    useradd -m vouch_user --uid=$UID --gid=$GID
+RUN groupadd -g $GID vouch \
+    && useradd --system vouch --uid=$UID --gid=$GID
 
 FROM alpine:latest
 LABEL maintainer="vouch@bnf.net"
@@ -27,10 +27,11 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 RUN apk add --no-cache bash
 COPY do.sh /do.sh
 
-COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+COPY --from=builder /go/bin/vouch-proxy /vouch-proxy
 
-USER vouch_user
+USER vouch
 
 EXPOSE 9090
 ENTRYPOINT ["/vouch-proxy"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,8 +12,11 @@ COPY . .
 RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details
 RUN ./do.sh install
-RUN groupadd -g 1001 vouch && \
-    useradd -m vouch_user --uid=1001 --gid=1001
+
+ARG UID=1001
+ARG GID=1001
+RUN groupadd -g $GID vouch && \
+    useradd -m vouch_user --uid=$UID --gid=$GID
 
 FROM alpine:latest
 LABEL maintainer="vouch@bnf.net"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Vouch Proxy supports many OAuth and OIDC login providers and can enforce authent
 - [OAuth2 Server Library for PHP](https://github.com/vouch/vouch-proxy/issues/99)
 - [HomeAssistant](https://developers.home-assistant.io/docs/en/auth_api.html)
 - [OpenStax](https://github.com/vouch/vouch-proxy/pull/141)
+- [Ory Hydra](https://github.com/vouch/vouch-proxy/issues/288)
 - [Nextcloud](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/oauth2.html)
 - most other OpenID Connect (OIDC) providers
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ docker run -d \
     quay.io/vouch/vouch-proxy
 ```
 
+As of `v0.36.0` the docker process in the container runs as user `vouch` with UID 999 and GID 999. You may need to set the permissions of `/config/config.yml` and `/config/secret` to correspond to be readable by this user, or otherwise use `docker run --user $UID:$GID ...` or perhaps build the docker container from source and use the available ARGs for UID and GID.
+
 Automated container builds for each Vouch Proxy release are available from [quay.io](https://quay.io/repository/vouch/vouch-proxy). Each release produces..
 
 a minimal go binary container built from `Dockerfile`

--- a/do.sh
+++ b/do.sh
@@ -11,8 +11,8 @@ if [ -z "$VOUCH_ROOT" ]; then
   export VOUCH_ROOT=${GOPATH}/src/github.com/vouch/vouch-proxy/
 fi
 
-IMAGE=voucher/vouch-proxy:latest
-ALPINE=voucher/vouch-proxy:alpine
+IMAGE=quay.io/vouch/vouch-proxy:latest
+ALPINE=quay.io/vouch/vouch-proxy:alpine-latest
 GOIMAGE=golang:1.16
 NAME=vouch-proxy
 HTTPPORT=9090
@@ -394,7 +394,7 @@ usage() {
      $0 bug_report domain.com [badstr2..]  - print config file and log removing secrets and each provided string
      $0 gogo [gocmd]                       - run, build, any go cmd
      $0 stats                              - simple metrics (lines of code in project, number of go files)
-     $0 watch [cmd]                        - watch the $CWD for any change and re-reun the [cmd]
+     $0 watch [cmd]                        - watch the \$CWD for any change and re-reun the [cmd] (defaults to 'go run main.go')
      $0 license [file]                     - apply the license to the file
 
   do is like make

--- a/pkg/cfg/jwt.go
+++ b/pkg/cfg/jwt.go
@@ -35,7 +35,8 @@ func getOrGenerateJWTSecret() string {
 		b = []byte(rstr)
 		err = ioutil.WriteFile(secretFile, b, 0600)
 		if err != nil {
-			log.Debug(err)
+			log.Error(err)
+			logSysInfo()
 		}
 	}
 	return string(b)


### PR DESCRIPTION
I'd like to be able to add the `runAsNonRoot: true` to my security context. This should make that work. 


Kubernetes:

```
  securityContext:
    runAsUser: 1001
    runAsGroup: 1001
```
