### PR TITLE
Set the username to name in the ofchance that it is still blank

### DIFF
--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -67,6 +67,10 @@ func (u *AzureUser) PrepareUserData() {
 		u.Username = u.PreferredUsername
 	}
 
+	if u.Username == "" {
+		u.Username = u.Name
+	}
+
 	if u.Email == "" {
 		u.Email = u.UPN
 	}


### PR DESCRIPTION
Had an issue authenticating with personal Azure domain. Name was returned, but UPN and PreferredUsername was blank. This makes vouch fail with the error: "no User found in jwt" although authentication was successful.