### PR TITLE
For multi-valued (array) claims, do not double-quote string values

### DIFF
--- a/handlers/validate.go
+++ b/handlers/validate.go
@@ -100,7 +100,11 @@ func generateCustomClaimsHeaders(w http.ResponseWriter, claims *jwtmanager.Vouch
 					if val, ok := v.([]interface{}); ok {
 						strs := make([]string, len(val))
 						for i, v := range val {
-							strs[i] = fmt.Sprintf("\"%s\"", v)
+							if reflect.TypeOf(v).Kind() == reflect.String {
+								strs[i] = v.(string)
+							} else {
+								strs[i] = fmt.Sprintf("\"%s\"", v)
+							}
 						}
 						log.Debugf("Adding header for claim %s - %s: %s", k, header, val)
 						w.Header().Add(header, strings.Join(strs, ","))


### PR DESCRIPTION
Single-value claims are not quoted (as one would expect), but the elements of multi-valued claims are even when they are already strings. This is inconsistent, and creates problems for downstream consumers since the original claim value(s) is(are) now corrupted with unexpected quotes. Example from logging:

`{"X-Vouch-Idp-Claims-Email":["user@company.com"],"X-Vouch-Idp-Claims-Name":["Joe User"],"X-Vouch-Idp-Claims-Roles":["\"user-role\""]`
...
`*ptokenCLaims: {user@company.com map[email:user@company.com name:Joe User roles:[user-role]]`
