### PR TITLE
Make WriteTimeout, ReadTimeout and IdleTimeout configurable

### DIFF
--- a/.defaults.yml
+++ b/.defaults.yml
@@ -15,6 +15,9 @@ vouch:
   publicAccess: false
   # whiteList:
   # teamWhitelist:
+  writeTimeout: 15
+  readTimeout: 15
+  idleTimeout: 15
 
   tls:
     # cert:

--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,6 @@ Dockerfile
 handlers/rice-box.go
 certs
 .cover/*
+.git
+.github
+.whitesource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
 
+- [allow configurable Write, Read and Idle timeouts for the http server](https://github.com/vouch/vouch-proxy/pull/468)
+
 ## v0.36.0
 
 - [run Docker containers as non-root user](https://github.com/vouch/vouch-proxy/pull/444)

--- a/config/config.yml_example
+++ b/config/config.yml_example
@@ -20,6 +20,17 @@ vouch:
   listen: 0.0.0.0  # VOUCH_LISTEN
   port: 9090       # VOUCH_PORT
 
+  # The default read, write and idle timeouts are 15 seconds.
+  # If you have a load balancer or proxy in front that has its
+  # own idle timeout, you may need to ensure that the Vouch idle
+  # timeout is longer than the proxy's, to avoid intermittent
+  # 502 errors.
+  # See https://github.com/vouch/vouch-proxy/issues/317 for more
+  # information.
+  writeTimeout: 15 # VOUCH_WRITETIMEOUT
+  readTimeout: 15  # VOUCH_READTIMEOUT
+  idleTimeout: 15  # VOUCH_IDLETIMEOUT
+
   # document_root - VOUCH_DOCUMENT_ROOT
   # see README for `Vouch Proxy "in a path"` - https://github.com/vouch/vouch-proxy#vouch-proxy-in-a-path
   # document_root: vp_in_a_path

--- a/config/config.yml_example_google
+++ b/config/config.yml_example_google
@@ -7,7 +7,7 @@ vouch:
   - yourdomain.com
   - yourotherdomain.com
 
-  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at Gitea
+  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate with Google
   # allowAllUsers: true
 
   cookie:
@@ -23,7 +23,7 @@ oauth:
   # https://console.developers.google.com/apis/credentials
   client_id: xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
   client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
-  # Google may require callbac_urls (redirect URIs) to be 'https'
+  # Google may require callback_urls (redirect URIs) to be 'https'
   callback_urls: 
     - https://yourdomain.com:9090/auth
     - https://yourotherdomain.com:9090/auth

--- a/main.go
+++ b/main.go
@@ -196,8 +196,9 @@ func main() {
 		Handler: router,
 		Addr:    listen,
 		// Good practice: enforce timeouts for servers you create!
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
+		WriteTimeout: time.Duration(cfg.Cfg.WriteTimeout) * time.Second,
+		ReadTimeout:  time.Duration(cfg.Cfg.ReadTimeout) * time.Second,
+		IdleTimeout:  time.Duration(cfg.Cfg.IdleTimeout) * time.Second,
 		ErrorLog:     log.New(&fwdToZapWriter{fastlog}, "", 0),
 	}
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -46,6 +46,9 @@ type Config struct {
 	Listen        string   `mapstructure:"listen"`
 	Port          int      `mapstructure:"port"`
 	DocumentRoot  string   `mapstructure:"document_root" envconfig:"document_root"`
+	WriteTimeout  int      `mapstructure:"writeTimeout"`
+	ReadTimeout   int      `mapstructure:"readTimeout"`
+	IdleTimeout   int      `mapstructure:"idleTimeout"`
 	Domains       []string `mapstructure:"domains"`
 	WhiteList     []string `mapstructure:"whitelist"`
 	TeamWhiteList []string `mapstructure:"teamWhitelist"`

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -138,7 +138,8 @@ func Test_configureFromEnvCfg(t *testing.T) {
 	// array of strings
 	saenv := []string{"VOUCH_DOMAINS", "VOUCH_WHITELIST", "VOUCH_TEAMWHITELIST", "VOUCH_HEADERS_CLAIMS", "VOUCH_TESTURLS", "VOUCH_POST_LOGOUT_REDIRECT_URIS"}
 	// int
-	ienv := []string{"VOUCH_PORT", "VOUCH_JWT_MAXAGE", "VOUCH_COOKIE_MAXAGE", "VOUCH_SESSION_MAXAGE"}
+	ienv := []string{"VOUCH_PORT", "VOUCH_JWT_MAXAGE", "VOUCH_COOKIE_MAXAGE", "VOUCH_SESSION_MAXAGE", "VOUCH_WRITETIMEOUT", "VOUCH_READTIMEOUT",
+		"VOUCH_IDLETIMEOUT"}
 	// bool
 	benv := []string{"VOUCH_ALLOWALLUSERS", "VOUCH_PUBLICACCESS", "VOUCH_JWT_COMPRESS", "VOUCH_COOKIE_SECURE",
 		"VOUCH_COOKIE_HTTPONLY", "VOUCH_TESTING"}
@@ -175,7 +176,7 @@ func Test_configureFromEnvCfg(t *testing.T) {
 	}
 
 	sacfg := [][]string{Cfg.Domains, Cfg.WhiteList, Cfg.TeamWhiteList, Cfg.Headers.Claims, Cfg.TestURLs, Cfg.LogoutRedirectURLs}
-	icfg := []int{Cfg.Port, Cfg.JWT.MaxAge, Cfg.Cookie.MaxAge}
+	icfg := []int{Cfg.Port, Cfg.JWT.MaxAge, Cfg.Cookie.MaxAge, Cfg.WriteTimeout, Cfg.ReadTimeout, Cfg.IdleTimeout}
 	bcfg := []bool{Cfg.AllowAllUsers, Cfg.PublicAccess, Cfg.JWT.Compress,
 		Cfg.Cookie.Secure,
 		Cfg.Cookie.HTTPOnly,


### PR DESCRIPTION
Closes #317 

This seems to fix the issue experienced in the aforementioned ticket, for me, and hopefully the original author. No more intermittent 502s from the ALB once I raised Vouch's timeouts to 65s (because the ALB's idle timeout is 60s and the [FIN/RST issue occurs as described here](https://www.tessian.com/blog/how-to-fix-http-502-errors/)). I am using the env vars so I know that works too.

As soon as I adjust the IdleTimeout value back to 15 (the default), the problem re-appears in my setup. That's the best proof of test I can offer... it might be hard for you to reproduce without a similar setup.

I am keeping the default timeouts to 15s to maintain the status quo. [From my reading](https://github.com/golang/go/blob/master/src/net/http/server.go#L2609-L2611), when IdleTimeout was not set (as it wasn't previously in Vouch), Go uses the value of ReadTimeout. So in effect, I don't think this will cause any issues for existing installations.


P.S after I built this, I had changes to versions/packages in go.mod / go.sum. At a glance, they looked like automatic upgrades to dependency packages pulled in via my `./do.sh goget`. I have excluded those changes here, as I don't consider them related to the change, but let me know if you want me to add them in.