### PR TITLE
Fix comments in Google example config

### DIFF
--- a/config/config.yml_example_google
+++ b/config/config.yml_example_google
@@ -7,7 +7,7 @@ vouch:
   - yourdomain.com
   - yourotherdomain.com
 
-  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at Gitea
+  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate with Google
   # allowAllUsers: true
 
   cookie:
@@ -23,7 +23,7 @@ oauth:
   # https://console.developers.google.com/apis/credentials
   client_id: xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com
   client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
-  # Google may require callbac_urls (redirect URIs) to be 'https'
+  # Google may require callback_urls (redirect URIs) to be 'https'
   callback_urls: 
     - https://yourdomain.com:9090/auth
     - https://yourotherdomain.com:9090/auth


### PR DESCRIPTION
The comment for `allowAllUsers` said `authenticate at Gitea`. Change it to say `authenticate with Google` (`with` seemed more appropriate than `at` here).

The comment for `callback_urls` said `callbac_urls`. I suppose that was a typo.