### PR TITLE
Mention github callback_url should be set to /auth

### DIFF
--- a/config/config.yml_example_github
+++ b/config/config.yml_example_github
@@ -38,7 +38,7 @@ oauth:
   # https://github.com/settings/applications/new
   #
   # callback_url is configured at github.com when setting up the app
-  # Set to e.g. https://vouch.yourdomain.com/auth
+  # Set to e.g. https://vouch.yourdomain.com/auth or https://yourdomain.com/vp_in_a_path/auth
   provider: github
   client_id: xxxxxxxxxxxxxxxxxxxx
   client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/config/config.yml_example_github
+++ b/config/config.yml_example_github
@@ -36,6 +36,9 @@ vouch:
 oauth:
   # create a new OAuth application at:
   # https://github.com/settings/applications/new
+  #
+  # callback_url is configured at github.com when setting up the app
+  # Set to e.g. https://vouch.yourdomain.com/auth
   provider: github
   client_id: xxxxxxxxxxxxxxxxxxxx
   client_secret: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
I missed the note about using `/auth` in the README.md when creating the github app.  I was mostly using the example config for github; a note there would have helped me.  So opening this PR to help others like me in the future :)