### PR TITLE
Support for auth0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
+- [support for auth0](https://github.com/vouch/vouch-proxy/pull/486)
 
 ## v0.37.0
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Vouch Proxy supports many OAuth and OIDC login providers and can enforce authent
 - [OpenStax](https://github.com/vouch/vouch-proxy/pull/141)
 - [Ory Hydra](https://github.com/vouch/vouch-proxy/issues/288)
 - [Nextcloud](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/oauth2.html)
+- [Auth0](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_auth0)
 - most other OpenID Connect (OIDC) providers
 
 Please do let us know when you have deployed Vouch Proxy with your preffered IdP or library so we can update the list.

--- a/config/config.yml_example_auth0
+++ b/config/config.yml_example_auth0
@@ -31,6 +31,6 @@ oauth:
   callback_url: https://vouch.yourdomain.com:9090/auth
 
 # Note: this provider can login directly to a specific auth0 organization
-# use 'x-vouch-orgid={orgId}' in /login redirect to make Vouch Proxy send 'organization={orgId}' in the authorize request
+# use 'x-vouch-orgid={orgId}' in /login redirect to make Vouch Proxy send 'organization={orgId}' in the authorize request (see https://auth0.com/docs/api/authentication#authorization-code-flow)
 # nginx redirect example: set $orgid variable and use 
 # https://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err&x-vouch-orgid=$orgid;

--- a/config/config.yml_example_auth0
+++ b/config/config.yml_example_auth0
@@ -1,0 +1,36 @@
+
+# Vouch Proxy configuration
+# bare minimum to get Vouch Proxy running with Auth0
+
+vouch:
+  # You can configure who can login by setting up various auth0 connections, 
+  # therefore we disable domain configuration in Vouch Proxy
+  # domains:
+  # - yourdomain.com
+
+  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at auth0
+  # and set vouch.cookie.domain to the domain you wish to protect
+  allowAllUsers: true
+
+  cookie:
+    secure: true
+    domain: yourdomain.com
+
+# set applicationDomain from your application dashboard in auth0
+oauth:
+  provider: auth0
+  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+  auth_url: https://{applicationDomain}/authorize
+  token_url: https://{applicationDomain}/oauth/token
+  user_info_url: https://{applicationDomain}/userinfo
+  scopes:
+    - openid
+    - email
+    - profile
+  callback_url: https://vouch.yourdomain.com:9090/auth
+
+# Note: this provider can login directly to a specific auth0 organization
+# use 'x-vouch-orgid={orgId}' in /login redirect to make Vouch Proxy send 'organization={orgId}' in the authorize request
+# nginx redirect example: set $orgid variable and use 
+# https://vouch.yourdomain.com/login?url=$scheme://$http_host$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err&x-vouch-orgid=$orgid;

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -88,6 +88,8 @@ func getProvider() Provider {
 		return openid.Provider{}
 	case cfg.Providers.Alibaba:
 		return alibaba.Provider{}
+	case cfg.Providers.Auth0:
+		return openid.Provider{}
 	default:
 		// shouldn't ever reach this since cfg checks for a properly configure `oauth.provider`
 		log.Fatal("oauth.provider appears to be misconfigured, please check your config")

--- a/handlers/login.go
+++ b/handlers/login.go
@@ -276,6 +276,15 @@ func oauthLoginURL(r *http.Request, session sessions.Session) string {
 	if cfg.OAuthopts != nil {
 		opts = append(opts, cfg.OAuthopts...)
 	}
+
+	// append auth0 organization if parameter was specified in /login?url=
+	if cfg.GenOAuth.Provider == cfg.Providers.Auth0 {
+		var orgid = r.URL.Query().Get("x-vouch-orgid")
+		if orgid != "" {
+			opts = append(opts, oauth2.SetAuthURLParam("organization", orgid))
+		}
+	}
+
 	return cfg.OAuthClient.AuthCodeURL(state, opts...)
 }
 

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -44,6 +44,7 @@ var (
 		OpenStax:      "openstax",
 		Nextcloud:     "nextcloud",
 		Alibaba:       "alibaba",
+		Auth0:         "auth0",
 	}
 )
 
@@ -59,6 +60,7 @@ type OAuthProviders struct {
 	OpenStax      string
 	Nextcloud     string
 	Alibaba       string
+	Auth0         string
 }
 
 // oauth config items endoint for access
@@ -122,7 +124,8 @@ func oauthBasicTest() error {
 		GenOAuth.Provider != Providers.OIDC &&
 		GenOAuth.Provider != Providers.OpenStax &&
 		GenOAuth.Provider != Providers.Nextcloud &&
-		GenOAuth.Provider != Providers.Alibaba {
+		GenOAuth.Provider != Providers.Alibaba &&
+		GenOAuth.Provider != Providers.Auth0 {
 		return errors.New("configuration error: Unknown oauth provider: " + GenOAuth.Provider)
 	}
 	// OAuthconfig Checks
@@ -131,18 +134,18 @@ func oauthBasicTest() error {
 		// everyone has a clientID
 		return errors.New("configuration error: oauth.client_id not found")
 	case GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.HomeAssistant && GenOAuth.Provider != Providers.ADFS && GenOAuth.Provider != Providers.OIDC && GenOAuth.ClientSecret == "":
-		// everyone except IndieAuth has a clientSecret
+		// everyone except IndieAuth and HomeAssistant has a clientSecret
 		// ADFS and OIDC providers also do not require this, but can have it optionally set.
 		return errors.New("configuration error: oauth.client_secret not found")
 	case GenOAuth.Provider != Providers.Google && GenOAuth.AuthURL == "":
-		// everyone except IndieAuth and Google has an authURL
+		// everyone except Google has an authURL
 		return errors.New("configuration error: oauth.auth_url not found")
 	case GenOAuth.Provider != Providers.Google && GenOAuth.Provider != Providers.IndieAuth && GenOAuth.Provider != Providers.HomeAssistant && GenOAuth.Provider != Providers.ADFS && GenOAuth.Provider != Providers.Azure && GenOAuth.UserInfoURL == "":
-		// everyone except IndieAuth, Google and ADFS has an userInfoURL, and Azure does not actively use it
+		// everyone except IndieAuth, Google, HomeAssistant and ADFS has an userInfoURL, and Azure does not actively use it
 		return errors.New("configuration error: oauth.user_info_url not found")
 	case GenOAuth.CodeChallengeMethod != "" && (GenOAuth.CodeChallengeMethod != "plain" && GenOAuth.CodeChallengeMethod != "S256"):
 		return errors.New("configuration error: oauth.code_challenge_method must be either 'S256' or 'plain'")
-	case GenOAuth.Provider == Providers.Azure || GenOAuth.Provider == Providers.ADFS || GenOAuth.Provider == Providers.Nextcloud || GenOAuth.Provider == Providers.OIDC:
+	case GenOAuth.Provider == Providers.Azure || GenOAuth.Provider == Providers.ADFS || GenOAuth.Provider == Providers.Nextcloud || GenOAuth.Provider == Providers.OIDC || GenOAuth.Provider == Providers.Auth0:
 		checkScopes([]string{"openid", "email", "profile"})
 	}
 


### PR DESCRIPTION
Hi all, this PR adds the following:
- `auth0` provider, which is essentially a named oidc provider without any extras
- `auth0` configuration example
- support for [organizations](https://auth0.com/docs/manage-users/organizations/using-tokens#authenticate-users-through-an-organization) concept in auth0, where `organization` parameter is added to the authorize call, thus skipping the organization selection screen and routing user directly into an organization specific login page. This is a great convenience when your users are members of other companies.

This is the approach I was able to make it work, feel free to challenge/suggest improvements.
Thanks.