### PR TITLE
Support reading secrets from a separate config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
 
+- [Support reading secrets from a separate file](https://github.com/vouch/vouch-proxy/pull/487)
+
 ## v0.37.0
 
 - [allow configurable Write, Read and Idle timeouts for the http server](https://github.com/vouch/vouch-proxy/pull/468)

--- a/config/testing/secret_overlay.yml
+++ b/config/testing/secret_overlay.yml
@@ -1,0 +1,2 @@
+oauth:
+  client_secret: my client secret from overlay


### PR DESCRIPTION
Users can specify a new overlay config file. This file can contain secrets. The file is specified in two ways:

Allow reading OauthClientId and OauthClientSecret from systemd LoadCredential directives.
    
 - `VOUCH_SECRETS_FILE` env var: path of the overlay config file
 - `CREDENTIALS_DIRECTORY` env var that contains a file called `VOUCH_SECRETS_FILE`. This can be used with the systemd `LoadCredential` directive.

Tested using both hardcoded secrets and LoadCredential files.
