### PR TITLE
Implements a Discord provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Coming soon! Please document any work in progress here as part of your PR. It will be moved to the next tag when released.
 
+* Implement a Discord provider that uses `Username` as the username to match against in the `whiteList` config
+  * Or uses `Username#Discriminator` if the Discriminator is present
+  * Or uses ID if `discord_use_ids` is set
+
 ## v0.40.0
 
 - upgrade golang to `v1.22` from `v1.18`

--- a/config/config.yml_example_discord
+++ b/config/config.yml_example_discord
@@ -7,9 +7,14 @@ vouch:
     - yourdomain.com
   # whiteList is a list of usernames that will allow a login if allowAllUsers is false
   whiteList:
+    # The default behavior matches the Discord user's username
     - loganintech
+
     # If the user still hasn't chosen a new username, the old username#discrimnator format will work
     - LoganInTech#1203
+
+    # If discord_use_ids is set to true, you must use the user's ID
+    - 81255545020878848
 
   cookie:
     # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com)
@@ -22,3 +27,5 @@ oauth:
   client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
   client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
   callback_url: http://vouch.yourdomain.com:9090/auth
+  ## Uncomment this to match users based on their Discord ID
+  # discord_use_ids: true

--- a/config/config.yml_example_discord
+++ b/config/config.yml_example_discord
@@ -5,9 +5,9 @@
 vouch:
   domains:
     - yourdomain.com
-  # whiteList is a list of username#discriminator that will allow a login if allowAllUsers is false
+  # whiteList is a list of user ids that will allow a login if allowAllUsers is false
   whiteList:
-    - loganintech#0001
+    - 12341234123412345
 
   cookie:
     # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com)

--- a/config/config.yml_example_discord
+++ b/config/config.yml_example_discord
@@ -14,7 +14,7 @@ vouch:
     - LoganInTech#1203
 
     # If discord_use_ids is set to true, you must use the user's ID
-    - 81255545020878848
+    - 12345678901234567
 
   cookie:
     # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com)

--- a/config/config.yml_example_discord
+++ b/config/config.yml_example_discord
@@ -1,13 +1,15 @@
 
 # Vouch Proxy configuration
-# bare minimum to get Vouch Proxy running with OpenID Connect (such as okta)
+# bare minimum to get Vouch Proxy running with Discord as an OpenID Provider
 
 vouch:
   domains:
     - yourdomain.com
-  # whiteList is a list of user ids that will allow a login if allowAllUsers is false
+  # whiteList is a list of usernames that will allow a login if allowAllUsers is false
   whiteList:
-    - 12341234123412345
+    - loganintech
+    # If the user still hasn't chosen a new username, the old username#discrimnator format will work
+    - LoganInTech#1203
 
   cookie:
     # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com)

--- a/config/config.yml_example_discord
+++ b/config/config.yml_example_discord
@@ -1,0 +1,22 @@
+
+# Vouch Proxy configuration
+# bare minimum to get Vouch Proxy running with OpenID Connect (such as okta)
+
+vouch:
+  domains:
+    - yourdomain.com
+  # whiteList is a list of username#discriminator that will allow a login if allowAllUsers is false
+  whiteList:
+    - loganintech#0001
+
+  cookie:
+    # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com)
+    secure: false
+    # vouch.cookie.domain must be set when enabling allowAllUsers
+    # domain: yourdomain.com
+
+oauth:
+  provider: discord
+  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+  callback_url: http://vouch.yourdomain.com:9090/auth

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/sessions"
+	"github.com/vouch/vouch-proxy/pkg/providers/discord"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
 
@@ -88,6 +89,8 @@ func getProvider() Provider {
 		return openid.Provider{}
 	case cfg.Providers.Alibaba:
 		return alibaba.Provider{}
+	case cfg.Providers.Discord:
+		return discord.Provider{}
 	default:
 		// shouldn't ever reach this since cfg checks for a properly configure `oauth.provider`
 		log.Fatal("oauth.provider appears to be misconfigured, please check your config")

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -290,7 +290,7 @@ func setDefaultsDiscord() {
 	if len(GenOAuth.Scopes) == 0 {
 		//Required for UserInfo URL
 		//https://discord.com/developers/docs/resources/user#get-current-user
-		GenOAuth.Scopes = []string{"identify"}
+		GenOAuth.Scopes = []string{"identify", "email"}
 	}
 	GenOAuth.CodeChallengeMethod = "S256"
 }

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -85,6 +85,7 @@ type oauthConfig struct {
 	PreferredDomain     string              `mapstructure:"preferredDomain"`
 	AzureToken          string              `mapstructure:"azure_token" envconfig:"azure_token"`
 	CodeChallengeMethod string              `mapstructure:"code_challenge_method" envconfig:"code_challenge_method"`
+	DiscordUseIDs       bool                `mapstructure:"discord_use_ids" envconfig:"discord_use_ids"`
 }
 
 type oauthClaimsConfig struct {
@@ -322,7 +323,10 @@ func checkCallbackConfig(url string) error {
 		}
 	}
 	if !found {
-		return fmt.Errorf("configuration error: oauth.callback_url (%s) must be within a configured domains where the cookie will be set: either `vouch.domains` %s or `vouch.cookie.domain` %s", url, Cfg.Domains, Cfg.Cookie.Domain)
+		return fmt.Errorf("configuration error: oauth.callback_url (%s) must be within a configured domains where the cookie will be set: either `vouch.domains` %s or `vouch.cookie.domain` %s",
+			url,
+			Cfg.Domains,
+			Cfg.Cookie.Domain)
 	}
 
 	return nil

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -44,6 +44,7 @@ var (
 		OpenStax:      "openstax",
 		Nextcloud:     "nextcloud",
 		Alibaba:       "alibaba",
+		Discord:       "discord",
 	}
 )
 
@@ -59,6 +60,7 @@ type OAuthProviders struct {
 	OpenStax      string
 	Nextcloud     string
 	Alibaba       string
+	Discord       string
 }
 
 // oauth config items endoint for access
@@ -122,7 +124,8 @@ func oauthBasicTest() error {
 		GenOAuth.Provider != Providers.OIDC &&
 		GenOAuth.Provider != Providers.OpenStax &&
 		GenOAuth.Provider != Providers.Nextcloud &&
-		GenOAuth.Provider != Providers.Alibaba {
+		GenOAuth.Provider != Providers.Alibaba &&
+		GenOAuth.Provider != Providers.Discord {
 		return errors.New("configuration error: Unknown oauth provider: " + GenOAuth.Provider)
 	}
 	// OAuthconfig Checks
@@ -187,6 +190,9 @@ func setProviderDefaults() {
 		configureOAuthClient()
 	} else if GenOAuth.Provider == Providers.IndieAuth {
 		GenOAuth.CodeChallengeMethod = "S256"
+		configureOAuthClient()
+	} else if GenOAuth.Provider == Providers.Discord {
+		setDefaultsDiscord()
 		configureOAuthClient()
 	} else {
 		// OIDC, OpenStax, Nextcloud
@@ -266,6 +272,25 @@ func setDefaultsGitHub() {
 		if len(Cfg.TeamWhiteList) > 0 {
 			GenOAuth.Scopes = append(GenOAuth.Scopes, "read:org")
 		}
+	}
+	GenOAuth.CodeChallengeMethod = "S256"
+}
+
+func setDefaultsDiscord() {
+	// log.Info("configuring GitHub OAuth")
+	if GenOAuth.AuthURL == "" {
+		GenOAuth.AuthURL = "https://discord.com/oauth2/authorize"
+	}
+	if GenOAuth.TokenURL == "" {
+		GenOAuth.TokenURL = "https://discord.com/api/oauth2/token"
+	}
+	if GenOAuth.UserInfoURL == "" {
+		GenOAuth.UserInfoURL = "https://discord.com/api/users/@me"
+	}
+	if len(GenOAuth.Scopes) == 0 {
+		//Required for UserInfo URL
+		//https://discord.com/developers/docs/resources/user#get-current-user
+		GenOAuth.Scopes = []string{"identify"}
 	}
 	GenOAuth.CodeChallengeMethod = "S256"
 }

--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -85,7 +85,9 @@ type oauthConfig struct {
 	PreferredDomain     string              `mapstructure:"preferredDomain"`
 	AzureToken          string              `mapstructure:"azure_token" envconfig:"azure_token"`
 	CodeChallengeMethod string              `mapstructure:"code_challenge_method" envconfig:"code_challenge_method"`
-	DiscordUseIDs       bool                `mapstructure:"discord_use_ids" envconfig:"discord_use_ids"`
+	// DiscordUseIDs defaults to false, maintaining the more common username checking behavior
+	// If set to true, match the Discord user's ID instead of their username
+	DiscordUseIDs bool `mapstructure:"discord_use_ids" envconfig:"discord_use_ids"`
 }
 
 type oauthClaimsConfig struct {

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -25,7 +25,9 @@ import (
 )
 
 // Provider provider specific functions
-type Provider struct{}
+type Provider struct {
+	UseSecureIDs bool
+}
 
 var log *zap.SugaredLogger
 

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -25,9 +25,7 @@ import (
 )
 
 // Provider provider specific functions
-type Provider struct {
-	UseSecureIDs bool
-}
+type Provider struct{}
 
 var log *zap.SugaredLogger
 

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -12,7 +12,7 @@ package discord
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"golang.org/x/oauth2"
@@ -48,7 +48,10 @@ func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *s
 			rerr = err
 		}
 	}()
-	data, _ := ioutil.ReadAll(userinfo.Body)
+	data, err := io.ReadAll(userinfo.Body)
+	if err != nil {
+		return err
+	}
 	log.Infof("Discord userinfo body: %s", string(data))
 	if err = common.MapClaims(data, customClaims); err != nil {
 		log.Error(err)

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -1,0 +1,66 @@
+/*
+
+Copyright 2020 The Vouch Proxy Authors.
+Use of this source code is governed by The MIT License (MIT) that
+can be found in the LICENSE file. Software distributed under The
+MIT License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+
+*/
+
+package discord
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"golang.org/x/oauth2"
+
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+	"github.com/vouch/vouch-proxy/pkg/providers/common"
+	"github.com/vouch/vouch-proxy/pkg/structs"
+	"go.uber.org/zap"
+)
+
+// Provider provider specific functions
+type Provider struct{}
+
+var log *zap.SugaredLogger
+
+// Configure see main.go configure()
+func (Provider) Configure() {
+	log = cfg.Logging.Logger
+}
+
+// GetUserInfo provider specific call to get userinfomation
+func (Provider) GetUserInfo(r *http.Request, user *structs.User, customClaims *structs.CustomClaims, ptokens *structs.PTokens, opts ...oauth2.AuthCodeOption) (rerr error) {
+	client, _, err := common.PrepareTokensAndClient(r, ptokens, true, opts...)
+	if err != nil {
+		return err
+	}
+	userinfo, err := client.Get(cfg.GenOAuth.UserInfoURL)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := userinfo.Body.Close(); err != nil {
+			rerr = err
+		}
+	}()
+	data, _ := ioutil.ReadAll(userinfo.Body)
+	log.Infof("Discord userinfo body: %s", string(data))
+	if err = common.MapClaims(data, customClaims); err != nil {
+		log.Error(err)
+		return err
+	}
+	discordUser := structs.DiscordUser{}
+	if err = json.Unmarshal(data, &discordUser); err != nil {
+		log.Error(err)
+		return err
+	}
+	discordUser.PrepareUserData()
+	user.Username = discordUser.PreparedUsername
+	user.Email = discordUser.Email
+	return nil
+}

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -12,15 +12,16 @@ package discord
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"golang.org/x/oauth2"
 
+	"go.uber.org/zap"
+
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/providers/common"
 	"github.com/vouch/vouch-proxy/pkg/structs"
-	"go.uber.org/zap"
 )
 
 // Provider provider specific functions

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -12,7 +12,7 @@ package discord
 
 import (
 	"encoding/json"
-	"io"
+	"io/ioutil"
 	"net/http"
 
 	"golang.org/x/oauth2"

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -255,8 +255,10 @@ type DiscordUser struct {
 	PreparedUsername string
 }
 
-// PrepareUserData copies the Username and Discriminator in the format that Discord guarantees to be unique
-// https://support.discord.com/hc/en-us/articles/4407571667351-Law-Enforcement-Guidelines Subheading "How to find usernames and discriminators"
+// PrepareUserData copies the Username to PreparedUsername. If the Discriminator is present that is
+// appended to the Username in the format "Username#Discriminator" to match the old format of Discord usernames
+// Previous format which is being phased out: https://support.discord.com/hc/en-us/articles/4407571667351-Law-Enforcement-Guidelines Subheading "How to find usernames and discriminators"
+// Details about the new username requirements: https://support.discord.com/hc/en-us/articles/12620128861463
 func (u *DiscordUser) PrepareUserData() {
 	u.PreparedUsername = u.Username
 	if u.Discriminator != "0" {

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -10,7 +10,10 @@ OR CONDITIONS OF ANY KIND, either express or implied.
 
 package structs
 
-import "strconv"
+import (
+	"fmt"
+	"strconv"
+)
 
 // CustomClaims Temporary struct storing custom claims until JWT creation.
 type CustomClaims struct {
@@ -148,7 +151,7 @@ type Contact struct {
 	Verified bool   `json:"is_verified"`
 }
 
-//OpenStaxUser is a retrieved and authenticated user from OpenStax Accounts
+// OpenStaxUser is a retrieved and authenticated user from OpenStax Accounts
 type OpenStaxUser struct {
 	User
 	Contacts []Contact `json:"contact_infos"`
@@ -239,4 +242,20 @@ type Site struct {
 type PTokens struct {
 	PAccessToken string
 	PIdToken     string
+}
+
+// DiscordUser deserializes values from the Discord User Object: https://discord.com/developers/docs/resources/user#user-object-user-structure
+type DiscordUser struct {
+	Id               string `json:"id"`
+	Username         string `json:"username"`
+	Discriminator    string `json:"discriminator"`
+	PreparedUsername string
+	Email            string `json:"email"`
+	Verified         bool   `json:"verified"`
+}
+
+// PrepareUserData copies the Username and Discriminator in the format that Discord guarantees to be unique
+// https://support.discord.com/hc/en-us/articles/4407571667351-Law-Enforcement-Guidelines Subheading "How to find usernames and discriminators"
+func (u *DiscordUser) PrepareUserData() {
+	u.PreparedUsername = fmt.Sprintf("%s#%s", u.Username, u.Discriminator)
 }

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -258,9 +258,8 @@ type DiscordUser struct {
 // PrepareUserData copies the Username and Discriminator in the format that Discord guarantees to be unique
 // https://support.discord.com/hc/en-us/articles/4407571667351-Law-Enforcement-Guidelines Subheading "How to find usernames and discriminators"
 func (u *DiscordUser) PrepareUserData() {
+	u.PreparedUsername = u.Username
 	if u.Discriminator != "0" {
 		u.PreparedUsername = fmt.Sprintf("%s#%s", u.Username, u.Discriminator)
-		return
 	}
-	u.PreparedUsername = u.GlobalName
 }

--- a/pkg/structs/structs.go
+++ b/pkg/structs/structs.go
@@ -249,13 +249,18 @@ type DiscordUser struct {
 	Id               string `json:"id"`
 	Username         string `json:"username"`
 	Discriminator    string `json:"discriminator"`
-	PreparedUsername string
+	GlobalName       string `json:"global_name"`
 	Email            string `json:"email"`
 	Verified         bool   `json:"verified"`
+	PreparedUsername string
 }
 
 // PrepareUserData copies the Username and Discriminator in the format that Discord guarantees to be unique
 // https://support.discord.com/hc/en-us/articles/4407571667351-Law-Enforcement-Guidelines Subheading "How to find usernames and discriminators"
 func (u *DiscordUser) PrepareUserData() {
-	u.PreparedUsername = fmt.Sprintf("%s#%s", u.Username, u.Discriminator)
+	if u.Discriminator != "0" {
+		u.PreparedUsername = fmt.Sprintf("%s#%s", u.Username, u.Discriminator)
+		return
+	}
+	u.PreparedUsername = u.GlobalName
 }


### PR DESCRIPTION
As was discussed in https://github.com/vouch/vouch-proxy/issues/312, Discord doesn't fulfill the proper spec for unique identification. They return a `User` object with `Username`, `Discriminator`, and `Id`. Discord guarantees a user's `Username#Discriminator` is unique across the app, so I've used that as the unique ID to be checked. This allows the `whiteList` array to have a list of usernames in the format that Discord users are used to, as opposed to their snowflake id.

I also had to bump the docker images go build versions because a dependency requires go1.19 but the images were on go1.18.

-----

An update to Discord's username specifications brings this more inline with other providers and removes discriminators. Now the username field is unique for each user provided they've taken the steps to select one.