### PR TITLE
Add some tools to dockerfile + update golang to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # quay.io/vouch/vouch-proxy
 # https://github.com/vouch/vouch-proxy
-FROM golang:1.18 AS builder
+FROM golang:1.20 AS builder
 
 ARG UID=999
 ARG GID=999

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN ./do.sh goget
 RUN ./do.sh gobuildstatic # see `do.sh` for vouch-proxy build details
 RUN ./do.sh install
 
-FROM scratch
+FROM debian:bookworm-slim
 LABEL maintainer="vouch@bnf.net"
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,6 +1,6 @@
 # quay.io/vouch/vouch-proxy
 # https://github.com/vouch/vouch-proxy
-FROM golang:1.18 AS builder
+FROM golang:1.20 AS builder
 
 ARG UID=999
 ARG GID=999

--- a/do.sh
+++ b/do.sh
@@ -13,7 +13,7 @@ fi
 
 IMAGE=quay.io/vouch/vouch-proxy:latest
 ALPINE=quay.io/vouch/vouch-proxy:alpine-latest
-GOIMAGE=golang:1.18
+GOIMAGE=golang:1.20
 NAME=vouch-proxy
 HTTPPORT=9090
 GODOC_PORT=5050


### PR DESCRIPTION
In my cluster, with a mean time to failure of 1-2 days, the vouch proxy gets the wrong TLS certificate from Keycloak, consistently, until restarted. I can't even try to copy in a bash executable because there is nothing but the golang bin! `kubectl` requires `tar` in the `PATH` to work at the very minimum.

I get the desire to trim container size, but you got to at least have `sh`, `tar`, and a package manager of some kind in my eyes.

EDIT: Also bumped golang to 1.20 to fix a build failure. I love dependencies changing out from under you.