### PR TITLE
Fix typo of handling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The variable `VOUCH_CONFIG` can be used to set an alternate location for the con
 All Vouch Proxy configuration items are documented in [config/config.yml_example](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example)
 
 - [Cacheing of the Vouch Proxy `/validate` response in Nginx](https://github.com/vouch/vouch-proxy/issues/76#issuecomment-464028743)
-- [Handleing `OPTIONS` requests when protecting an API with Vouch Proxy](https://github.com/vouch/vouch-proxy/issues/216)
+- [Handling `OPTIONS` requests when protecting an API with Vouch Proxy](https://github.com/vouch/vouch-proxy/issues/216)
 - [Validation by GitHub Team or GitHub Org](https://github.com/vouch/vouch-proxy/pull/205)
 - [Running VP on a Raspberry Pi using the ARM based Docker image](https://github.com/vouch/vouch-proxy/pull/247)
 - [Kubernetes architecture post ingress](https://github.com/vouch/vouch-proxy/pull/263#issuecomment-628297832)


### PR DESCRIPTION
I know this is a minor PR, but I thought it was worth fixing the typo in case someone was searching and couldn’t find the result because of it.