### PR TITLE
Implement TeamWhiteList functionality for OIDC providers

### DIFF
--- a/pkg/cfg/oauth.go
+++ b/pkg/cfg/oauth.go
@@ -83,6 +83,7 @@ type oauthConfig struct {
 	PreferredDomain     string              `mapstructure:"preferredDomain"`
 	AzureToken          string              `mapstructure:"azure_token" envconfig:"azure_token"`
 	CodeChallengeMethod string              `mapstructure:"code_challenge_method" envconfig:"code_challenge_method"`
+	TeamWhiteListClaim  string              `mapstructure:"team_whitelist_claim" envconfig:"team_whitelist_claim"`
 }
 
 type oauthClaimsConfig struct {


### PR DESCRIPTION
- Add new config option TeamWhiteListClaim that references the UserInfo parameter that contains an array of teams the user is part of
- Add matching teams to the users TeamMemberships field

Solves #589