### PR TITLE
docs: add pocket-id config example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ main
 config/config.yml
 config/*config.yml
 config/config.yml_*
+!config.yml_example_pocket-id
 config/google_config.json
 config/secret
 !config/testing/*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Vouch Proxy supports many OAuth and OIDC login providers and can enforce authent
 - [OpenStax](https://github.com/vouch/vouch-proxy/pull/141)
 - [Ory Hydra](https://github.com/vouch/vouch-proxy/issues/288)
 - [Nextcloud](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/oauth2.html)
+- [Pocket ID](https://github.com/vouch/vouch-proxy/blob/master/config/config.yml_example_pocket-id)
 - most other OpenID Connect (OIDC) providers
 
 Please do let us know when you have deployed Vouch Proxy with your preffered IdP or library so we can update the list.

--- a/config/config.yml_example_pocket-id
+++ b/config/config.yml_example_pocket-id
@@ -1,0 +1,37 @@
+
+# Vouch Proxy configuration
+# bare minimum to get Vouch Proxy running with pocket-id
+
+vouch:
+  # domains:
+  # valid domains that the jwt cookies can be set into
+  # the callback_urls will be to these domains
+  domains:
+  - yourdomain.com
+  - yourotherdomain.com
+
+  # - OR -
+  # instead of setting specific domains you may prefer to allow all users...
+  # set allowAllUsers: true to use Vouch Proxy to just accept anyone who can authenticate at the configured provider
+  # and set vouch.cookie.domain to the domain you wish to protect
+  # allowAllUsers: true
+
+  cookie:
+    # allow the jwt/cookie to be set into http://yourdomain.com (defaults to true, requiring https://yourdomain.com) 
+    secure: false
+    # vouch.cookie.domain must be set when enabling allowAllUsers
+    # domain: yourdomain.com
+
+oauth:
+  # pocket-id
+  provider: oidc
+  client_id: xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  client_secret: xxxxxxxxxxxxxxxxxxxxxxxx
+  auth_url: https://{yourPocketIdDomain}/authorize
+  token_url: https://{yourPocketIdDomain}/api/oidc/token
+  user_info_url: https://{yourPocketIdDomain}/api/oidc/userinfo
+  scopes:
+    - openid
+    - email
+    - profile
+  callback_url: http://vouch.{yourdomain.com}/auth


### PR DESCRIPTION
I’ve installed pocket-id (a simple OIDC provider) configured with vouch-proxy.
I propose to add a sample configuration file and pocket-id in README.md to help future users.