### PR TITLE
Add multi-part session cookie support to fix long URL issue

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vouch/vouch-proxy/pkg/providers/nextcloud"
 	"github.com/vouch/vouch-proxy/pkg/providers/openid"
 	"github.com/vouch/vouch-proxy/pkg/providers/openstax"
+	"github.com/vouch/vouch-proxy/pkg/session"
 	"github.com/vouch/vouch-proxy/pkg/structs"
 )
 
@@ -45,7 +46,7 @@ const (
 )
 
 var (
-	sessstore *sessions.CookieStore
+	sessstore sessions.Store
 	log       *zap.SugaredLogger
 	fastlog   *zap.Logger
 	provider  Provider
@@ -55,12 +56,14 @@ var (
 func Configure() {
 	log = cfg.Logging.Logger
 	fastlog = cfg.Logging.FastLogger
-	// http://www.gorillatoolkit.org/pkg/sessions
-	sessstore = sessions.NewCookieStore([]byte(cfg.Cfg.Session.Key))
-	sessstore.Options.HttpOnly = cfg.Cfg.Cookie.HTTPOnly
-	sessstore.Options.Secure = cfg.Cfg.Cookie.Secure
-	sessstore.Options.SameSite = cookie.SameSite()
-	sessstore.Options.MaxAge = cfg.Cfg.Session.MaxAge * 60 // convert minutes to seconds
+	// Use MultiPartCookieStore to support large session cookies (long URLs)
+	// This fixes https://github.com/vouch/vouch-proxy/issues/348
+	multiPartStore := session.NewMultiPartCookieStore([]byte(cfg.Cfg.Session.Key))
+	multiPartStore.Options.HttpOnly = cfg.Cfg.Cookie.HTTPOnly
+	multiPartStore.Options.Secure = cfg.Cfg.Cookie.Secure
+	multiPartStore.Options.SameSite = cookie.SameSite()
+	multiPartStore.Options.MaxAge = cfg.Cfg.Session.MaxAge * 60 // convert minutes to seconds
+	sessstore = multiPartStore
 
 	provider = getProvider()
 	provider.Configure()

--- a/pkg/session/multipart_store.go
+++ b/pkg/session/multipart_store.go
@@ -1,0 +1,309 @@
+/*
+
+Copyright 2020 The Vouch Proxy Authors.
+Use of this source code is governed by The MIT License (MIT) that
+can be found in the LICENSE file. Software distributed under The
+MIT License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+OR CONDITIONS OF ANY KIND, either express or implied.
+
+*/
+
+package session
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+)
+
+// maxCookieSize is the maximum size of a single Set-Cookie header value.
+// Browsers typically limit cookies to 4096 bytes, but this includes the
+// cookie name, path, domain, and other attributes - not just the value.
+// We use 3800 to leave ~300 bytes of headroom for this metadata.
+const maxCookieSize = 3800
+
+// MultiPartCookieStore is a session store that splits large session cookies
+// into multiple parts, similar to how Vouch handles JWT cookies.
+// This fixes https://github.com/vouch/vouch-proxy/issues/348
+type MultiPartCookieStore struct {
+	Codecs  []securecookie.Codec
+	Options *sessions.Options
+}
+
+// NewMultiPartCookieStore creates a new MultiPartCookieStore with the given key pairs.
+func NewMultiPartCookieStore(keyPairs ...[]byte) *MultiPartCookieStore {
+	codecs := securecookie.CodecsFromPairs(keyPairs...)
+	// Increase the max length for the securecookie encoder
+	// We'll handle splitting into multiple cookies ourselves
+	for _, codec := range codecs {
+		if sc, ok := codec.(*securecookie.SecureCookie); ok {
+			// Set a very high limit - we'll split the result into multiple cookies
+			sc.MaxLength(0) // 0 means unlimited
+		}
+	}
+	return &MultiPartCookieStore{
+		Codecs: codecs,
+		Options: &sessions.Options{
+			Path:   "/",
+			MaxAge: 86400,
+		},
+	}
+}
+
+// Get returns a session for the given name after adding it to the registry.
+func (s *MultiPartCookieStore) Get(r *http.Request, name string) (*sessions.Session, error) {
+	return sessions.GetRegistry(r).Get(s, name)
+}
+
+// New returns a session for the given name without adding it to the registry.
+func (s *MultiPartCookieStore) New(r *http.Request, name string) (*sessions.Session, error) {
+	session := sessions.NewSession(s, name)
+	opts := *s.Options
+	session.Options = &opts
+	session.IsNew = true
+
+	// Try to load existing session from cookies
+	value, err := s.readMultiPartCookie(r, name)
+	if errors.Is(err, http.ErrNoCookie) {
+		return session, nil
+	}
+	if err != nil {
+		return session, err
+	}
+
+	err = securecookie.DecodeMulti(name, value, &session.Values, s.Codecs...)
+	if err == nil {
+		session.IsNew = false
+	}
+	return session, err
+}
+
+// Save adds a single session to the response.
+func (s *MultiPartCookieStore) Save(r *http.Request, w http.ResponseWriter, session *sessions.Session) error {
+	// Delete if max-age is <= 0
+	if session.Options.MaxAge <= 0 {
+		s.deleteMultiPartCookie(w, r, session.Name(), session.Options)
+		return nil
+	}
+
+	// Encode the session
+	encoded, err := securecookie.EncodeMulti(session.Name(), session.Values, s.Codecs...)
+	if err != nil {
+		return err
+	}
+
+	// Write the cookie(s)
+	return s.writeMultiPartCookie(w, r, session.Name(), encoded, session.Options)
+}
+
+// readMultiPartCookie reads a potentially multi-part cookie value
+func (s *MultiPartCookieStore) readMultiPartCookie(r *http.Request, name string) (string, error) {
+	cookies := r.Cookies()
+	var singleValue string
+	var hasSingle bool
+	parts := make(map[int]string)
+	var totalParts int
+
+	partPattern := regexp.MustCompile(fmt.Sprintf(`^%s_(\d+)of(\d+)$`, regexp.QuoteMeta(name)))
+
+	for _, cookie := range cookies {
+		if cookie.Name == name {
+			singleValue = cookie.Value
+			hasSingle = true
+			continue
+		}
+		matches := partPattern.FindStringSubmatch(cookie.Name)
+		if matches != nil {
+			partNum, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return "", fmt.Errorf("invalid part number in cookie %q: %w", cookie.Name, err)
+			}
+			total, err := strconv.Atoi(matches[2])
+			if err != nil {
+				return "", fmt.Errorf("invalid total in cookie %q: %w", cookie.Name, err)
+			}
+			if totalParts == 0 {
+				totalParts = total
+			} else if totalParts != total {
+				return "", fmt.Errorf("inconsistent multipart cookie totals for %q: got %d and %d", name, totalParts, total)
+			}
+			if partNum < 1 || partNum > total {
+				return "", fmt.Errorf("invalid cookie part number %d for total %d", partNum, total)
+			}
+			parts[partNum] = cookie.Value
+		}
+	}
+
+	if totalParts > 0 {
+		// Reassemble parts in order. Prefer multipart if present so stale
+		// single cookies don't override a newer multipart session.
+		var combined strings.Builder
+		for i := 1; i <= totalParts; i++ {
+			if part, ok := parts[i]; ok {
+				combined.WriteString(part)
+			} else {
+				return "", fmt.Errorf("missing cookie part %d of %d", i, totalParts)
+			}
+		}
+		return combined.String(), nil
+	}
+
+	if hasSingle {
+		return singleValue, nil
+	}
+
+	return "", http.ErrNoCookie
+}
+
+// writeMultiPartCookie writes a cookie, splitting into multiple parts if necessary
+func (s *MultiPartCookieStore) writeMultiPartCookie(w http.ResponseWriter, r *http.Request, name, value string, options *sessions.Options) error {
+	// First, clear any existing multi-part cookies (only the parts, not the main cookie)
+	s.clearMultiPartCookieParts(w, r, name, options)
+
+	// Calculate if we need to split
+	testCookie := &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	}
+
+	if len(testCookie.String()) <= maxCookieSize {
+		// Single cookie is fine
+		http.SetCookie(w, testCookie)
+		return nil
+	}
+
+	// Need to split - calculate available space for value per cookie
+	emptyCookie := &http.Cookie{
+		Name:     name + "_99of99", // Use longest possible name format
+		Value:    "",
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   options.MaxAge,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	}
+	maxValueLen := maxCookieSize - len(emptyCookie.String())
+	if maxValueLen <= 0 {
+		return fmt.Errorf("cookie metadata too large, no room for value")
+	}
+
+	// Ensure any previously-written single cookie is removed, otherwise it can
+	// coexist in some clients and shadow the multipart cookie on read.
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   -1,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	})
+
+	// Split the value
+	parts := splitString(value, maxValueLen)
+
+	// Write each part
+	for i, part := range parts {
+		partName := fmt.Sprintf("%s_%dof%d", name, i+1, len(parts))
+		http.SetCookie(w, &http.Cookie{
+			Name:     partName,
+			Value:    part,
+			Path:     options.Path,
+			Domain:   options.Domain,
+			MaxAge:   options.MaxAge,
+			Secure:   options.Secure,
+			HttpOnly: options.HttpOnly,
+			SameSite: options.SameSite,
+		})
+	}
+
+	return nil
+}
+
+// clearMultiPartCookieParts clears only the multi-part cookie parts (not the main cookie)
+// This is used when writing a new value to avoid leaving stale parts
+func (s *MultiPartCookieStore) clearMultiPartCookieParts(w http.ResponseWriter, r *http.Request, name string, options *sessions.Options) {
+	cookies := r.Cookies()
+	partPattern := regexp.MustCompile(fmt.Sprintf(`^%s_\d+of\d+$`, regexp.QuoteMeta(name)))
+
+	for _, cookie := range cookies {
+		if partPattern.MatchString(cookie.Name) {
+			http.SetCookie(w, &http.Cookie{
+				Name:     cookie.Name,
+				Value:    "",
+				Path:     options.Path,
+				Domain:   options.Domain,
+				MaxAge:   -1,
+				Secure:   options.Secure,
+				HttpOnly: options.HttpOnly,
+				SameSite: options.SameSite,
+			})
+		}
+	}
+}
+
+// deleteMultiPartCookie deletes a cookie and any multi-part variants
+func (s *MultiPartCookieStore) deleteMultiPartCookie(w http.ResponseWriter, r *http.Request, name string, options *sessions.Options) {
+	// Delete the main cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     options.Path,
+		Domain:   options.Domain,
+		MaxAge:   -1,
+		Secure:   options.Secure,
+		HttpOnly: options.HttpOnly,
+		SameSite: options.SameSite,
+	})
+
+	// Also delete any multi-part cookies
+	s.clearMultiPartCookieParts(w, r, name, options)
+}
+
+// splitString splits a string into parts of at most maxLen bytes,
+// respecting UTF-8 character boundaries
+func splitString(s string, maxLen int) []string {
+	if len(s) == 0 {
+		return []string{""}
+	}
+	if maxLen <= 0 {
+		return []string{s}
+	}
+
+	var parts []string
+	for len(s) > 0 {
+		if len(s) <= maxLen {
+			parts = append(parts, s)
+			break
+		}
+
+		// Find a safe split point that doesn't break UTF-8
+		splitAt := maxLen
+		for splitAt > 0 && !utf8.RuneStart(s[splitAt]) {
+			splitAt--
+		}
+		if splitAt == 0 {
+			// Shouldn't happen with valid UTF-8, but fallback
+			splitAt = maxLen
+		}
+
+		parts = append(parts, s[:splitAt])
+		s = s[splitAt:]
+	}
+	return parts
+}

--- a/pkg/session/multipart_store_test.go
+++ b/pkg/session/multipart_store_test.go
@@ -1,0 +1,340 @@
+package session
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSplitString(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   int // number of parts expected
+	}{
+		{"empty", "", 100, 1},
+		{"short", "hello", 100, 1},
+		{"exact", "hello", 5, 1},
+		{"split two", "hello world", 6, 2},
+		{"split many", strings.Repeat("a", 1000), 100, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts := splitString(tt.input, tt.maxLen)
+			if len(parts) != tt.want {
+				t.Errorf("splitString() got %d parts, want %d", len(parts), tt.want)
+			}
+			// Verify we can reconstruct
+			combined := strings.Join(parts, "")
+			if combined != tt.input {
+				t.Errorf("splitString() reconstructed = %q, want %q", combined, tt.input)
+			}
+		})
+	}
+}
+
+func TestMultiPartCookieStore_SmallSession(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+
+	// Create a request/response
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	// Get a new session
+	session, err := store.Get(req, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Store a small value
+	session.Values["url"] = "https://example.com/short"
+	session.Options.MaxAge = 300
+
+	// Save the session
+	err = store.Save(req, rec, session)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Check that we got exactly one cookie (not split)
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Errorf("Expected 1 cookie for small session, got %d", len(cookies))
+	}
+	if cookies[0].Name != "test-session" {
+		t.Errorf("Cookie name = %q, want %q", cookies[0].Name, "test-session")
+	}
+}
+
+func TestMultiPartCookieStore_LargeSession(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+
+	// Create a request/response
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	// Get a new session
+	session, err := store.Get(req, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+
+	// Store a very long URL (like the Grafana URL that triggered the bug)
+	longURL := "https://metrics.example.com/explore?schemaVersion=1&panes=" + strings.Repeat("A", 3000)
+	session.Values["requestedURL"] = longURL
+	session.Values[longURL] = 1 // failcount
+	session.Values["state"] = "some-random-state-nonce"
+	session.Options.MaxAge = 300
+
+	// Save the session
+	err = store.Save(req, rec, session)
+	if err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Check that we got multiple cookies (split)
+	cookies := rec.Result().Cookies()
+	if len(cookies) < 2 {
+		t.Errorf("Expected multiple cookies for large session, got %d", len(cookies))
+	}
+
+	// Verify cookie naming pattern
+	foundParts := 0
+	for _, c := range cookies {
+		if strings.Contains(c.Name, "of") {
+			foundParts++
+		}
+	}
+	if foundParts < 2 {
+		t.Errorf("Expected at least 2 multipart cookies, found %d", foundParts)
+	}
+
+	// Now verify we can read the session back
+	req2 := httptest.NewRequest("GET", "/", nil)
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+
+	session2, err := store.Get(req2, "test-session")
+	if err != nil {
+		t.Fatalf("Get() on read-back error = %v", err)
+	}
+
+	if session2.IsNew {
+		t.Error("Expected session to be loaded, but IsNew = true")
+	}
+
+	gotURL, ok := session2.Values["requestedURL"].(string)
+	if !ok || gotURL != longURL {
+		t.Errorf("Read back requestedURL = %q, want %q", gotURL, longURL)
+	}
+}
+
+func TestMultiPartCookieStore_DeleteSession(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+
+	// Create a large session first
+	req := httptest.NewRequest("GET", "/", nil)
+	rec := httptest.NewRecorder()
+
+	session, _ := store.Get(req, "test-session")
+	session.Values["data"] = strings.Repeat("X", 5000)
+	session.Options.MaxAge = 300
+	store.Save(req, rec, session)
+
+	cookies := rec.Result().Cookies()
+
+	// Now delete the session
+	req2 := httptest.NewRequest("GET", "/", nil)
+	for _, c := range cookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+
+	session2, _ := store.Get(req2, "test-session")
+	session2.Options.MaxAge = -1 // Mark for deletion
+	store.Save(req2, rec2, session2)
+
+	// All cookies should be deleted (MaxAge = -1)
+	deleteCookies := rec2.Result().Cookies()
+	for _, c := range deleteCookies {
+		if c.MaxAge != -1 {
+			t.Errorf("Cookie %s should have MaxAge=-1 for deletion, got %d", c.Name, c.MaxAge)
+		}
+	}
+}
+
+func TestMultiPartCookieStore_PrefersMultipartOverStaleSingle(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+
+	// First write a small session (single cookie).
+	req1 := httptest.NewRequest("GET", "/", nil)
+	rec1 := httptest.NewRecorder()
+	session1, err := store.Get(req1, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	session1.Values["payload"] = "small"
+	session1.Options.MaxAge = 300
+	if err := store.Save(req1, rec1, session1); err != nil {
+		t.Fatalf("Save(small) error = %v", err)
+	}
+	smallCookies := rec1.Result().Cookies()
+
+	// Then write a large session (multipart), using prior cookies in the request.
+	req2 := httptest.NewRequest("GET", "/", nil)
+	for _, c := range smallCookies {
+		req2.AddCookie(c)
+	}
+	rec2 := httptest.NewRecorder()
+	session2, err := store.Get(req2, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	largeValue := strings.Repeat("X", 10000)
+	session2.Values["payload"] = largeValue
+	session2.Options.MaxAge = 300
+	if err := store.Save(req2, rec2, session2); err != nil {
+		t.Fatalf("Save(large) error = %v", err)
+	}
+
+	// Simulate a client that still sends a stale single cookie alongside new
+	// multipart cookies: multipart must win.
+	req3 := httptest.NewRequest("GET", "/", nil)
+	for _, c := range smallCookies {
+		if c.Name == "test-session" {
+			req3.AddCookie(c)
+		}
+	}
+	for _, c := range rec2.Result().Cookies() {
+		if strings.Contains(c.Name, "of") {
+			req3.AddCookie(c)
+		}
+	}
+
+	session3, err := store.Get(req3, "test-session")
+	if err != nil {
+		t.Fatalf("Get() read-back error = %v", err)
+	}
+	got, ok := session3.Values["payload"].(string)
+	if !ok {
+		t.Fatalf("payload type = %T, want string", session3.Values["payload"])
+	}
+	if got != largeValue {
+		t.Fatalf("payload len = %d, want %d", len(got), len(largeValue))
+	}
+}
+
+func TestMultiPartCookieStore_GetReturnsErrorOnInvalidCookie(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+
+	req1 := httptest.NewRequest("GET", "/", nil)
+	rec1 := httptest.NewRecorder()
+	session1, err := store.Get(req1, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	session1.Values["payload"] = "valid"
+	session1.Options.MaxAge = 300
+	if err := store.Save(req1, rec1, session1); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	validCookies := rec1.Result().Cookies()
+	req2 := httptest.NewRequest("GET", "/", nil)
+	for _, c := range validCookies {
+		if c.Name == "test-session" {
+			tampered := *c
+			tampered.Value = c.Value + "tampered"
+			req2.AddCookie(&tampered)
+		}
+	}
+
+	session2, err := store.Get(req2, "test-session")
+	if err == nil {
+		t.Fatal("Get() error = nil, want decode error")
+	}
+	if session2 == nil {
+		t.Fatal("Get() session is nil, want non-nil session")
+	}
+	if !session2.IsNew {
+		t.Fatal("session.IsNew = false, want true for decode failure")
+	}
+}
+
+func TestMultiPartCookieStore_GetReturnsErrorOnMissingMultipartPart(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+
+	req1 := httptest.NewRequest("GET", "/", nil)
+	rec1 := httptest.NewRecorder()
+	session1, err := store.Get(req1, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	session1.Values["payload"] = strings.Repeat("X", 10000)
+	session1.Options.MaxAge = 300
+	if err := store.Save(req1, rec1, session1); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	// Drop one part from the request to force a reassembly error.
+	req2 := httptest.NewRequest("GET", "/", nil)
+	dropped := false
+	for _, c := range rec1.Result().Cookies() {
+		if strings.Contains(c.Name, "of") && !dropped {
+			dropped = true
+			continue
+		}
+		req2.AddCookie(c)
+	}
+
+	session2, err := store.Get(req2, "test-session")
+	if err == nil {
+		t.Fatal("Get() error = nil, want multipart read error")
+	}
+	if session2 == nil {
+		t.Fatal("Get() session is nil, want non-nil session")
+	}
+	if !session2.IsNew {
+		t.Fatal("session.IsNew = false, want true for read failure")
+	}
+}
+
+func TestMultiPartCookieStore_GetNoCookieStillReturnsIsNew(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+	req := httptest.NewRequest("GET", "/", nil)
+
+	session, err := store.Get(req, "test-session")
+	if err != nil {
+		t.Fatalf("Get() error = %v, want nil", err)
+	}
+	if !session.IsNew {
+		t.Fatal("session.IsNew = false, want true when no cookie exists")
+	}
+}
+
+func TestMultiPartCookieStore_NewNoCookieStillReturnsIsNew(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+	req := httptest.NewRequest("GET", "/", nil)
+
+	session, err := store.New(req, "test-session")
+	if err != nil {
+		t.Fatalf("New() error = %v, want nil", err)
+	}
+	if !session.IsNew {
+		t.Fatal("session.IsNew = false, want true when no cookie exists")
+	}
+}
+
+func TestMultiPartCookieStore_NewReturnsErrNoCookieOnlyInternally(t *testing.T) {
+	store := NewMultiPartCookieStore([]byte("secret-key-that-is-at-least-32-bytes-long!!"))
+	req := httptest.NewRequest("GET", "/", nil)
+
+	_, err := store.readMultiPartCookie(req, "test-session")
+	if err == nil || err != http.ErrNoCookie {
+		t.Fatalf("readMultiPartCookie() error = %v, want %v", err, http.ErrNoCookie)
+	}
+}


### PR DESCRIPTION
Related issue: https://github.com/vouch/vouch-proxy/issues/348

The problem: When a user visits a protected URL that is very long (e.g., a Grafana explore URL with a complex query), the session cookie exceeds the securecookie MaxLength of 4096 bytes, causing a "securecookie: the value is too long" error. This breaks the OAuth flow - the session isn't saved, so when the OAuth callback returns, the state validation fails with "Invalid session state".

The solution: Implement a MultiPartCookieStore that:
1. Removes the securecookie MaxLength limit (we handle size ourselves)
2. Automatically splits large session cookies into multiple parts (e.g., VouchSession_1of3, VouchSession_2of3, VouchSession_3of3)
3. Reassembles the parts when reading the session back

This approach mirrors how Vouch already handles large JWT cookies in pkg/cookie/cookie.go.

The change is backwards compatible - existing session cookies will continue to work because:
- The store first tries to read a single cookie before looking for parts
- The same securecookie encoding is used
- Small sessions are still written as single cookies