### PR TITLE
Fix broken Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # quay.io/vouch/vouch-proxy
 # https://github.com/vouch/vouch-proxy
-FROM golang:1.23 AS builder
+FROM golang:1.24 AS builder
 
 ARG UID=999
 ARG GID=999


### PR DESCRIPTION
`docker build` is broken because go 1.24 is required by dependencies:
- golang.org/x/text@v0.33.0 requires go >= 1.24.0
- golang.org/x/sys@v0.40.0 requires go >= 1.24.0
