### PR TITLE
fix SiteInAudience for legacy comma-separated audience claims

### DIFF
--- a/pkg/jwtmanager/jwtmanager.go
+++ b/pkg/jwtmanager/jwtmanager.go
@@ -161,9 +161,13 @@ func ParseTokenString(tokenString string) (*jwt.Token, error) {
 // SiteInAudience does the claim contain the value?
 func (claims *VouchClaims) SiteInAudience(s string) bool {
 	for _, a := range claims.Audience {
-		if s == a || strings.HasSuffix(s, "."+a) {
-			log.Debugf("site %s is found for claims.Audience %s", s, a)
-			return true
+		// jwt/v4 serialized the audience as a comma-separated string;
+		// jwt/v5 deserializes that into a single-element []string.
+		for _, d := range strings.Split(a, comma) {
+			if s == d || strings.HasSuffix(s, "."+d) {
+				log.Debugf("site %s is found for claims.Audience %s", s, d)
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/jwtmanager/jwtmanager_test.go
+++ b/pkg/jwtmanager/jwtmanager_test.go
@@ -16,10 +16,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/vouch/vouch-proxy/pkg/cfg"
 	"github.com/vouch/vouch-proxy/pkg/structs"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -110,16 +111,16 @@ func TestClaims(t *testing.T) {
 
 func TestVouchClaims_SiteInAudience(t *testing.T) {
 	tests := []struct {
-		name    string // description of this test case
+		name    string
 		cfgFile string
 		s       string
 		want    bool
 	}{
-		// test cases
-		{"vouch.github.io", "test_config_oauth_claims.yml", "vouch.github.io", true},
-		{"evilvouch.github.io", "test_config_oauth_claims.yml", "evilvouch.github.io", false},
-		{"vouch.github.io.attacker.com", "test_config_oauth_claims.yml", "vouch.github.io.attacker.com", false},
-		{"evilvouch.github.io.attacker.com", "test_config_oauth_claims.yml", "evilvouch.github.io.attacker.com", false},
+		{"exact match", "test_config_oauth_claims.yml", "vouch.github.io", true},
+		{"subdomain match", "test_config_oauth_claims.yml", "sub.vouch.github.io", true},
+		{"suffix attack", "test_config_oauth_claims.yml", "evilvouch.github.io", false},
+		{"attacker parent domain", "test_config_oauth_claims.yml", "vouch.github.io.attacker.com", false},
+		{"attacker combined", "test_config_oauth_claims.yml", "evilvouch.github.io.attacker.com", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,9 +132,39 @@ func TestVouchClaims_SiteInAudience(t *testing.T) {
 				t.Fatalf("could not construct receiver type: %v", err)
 			}
 			got := claims.SiteInAudience(tt.s)
-			// TODO: update the condition below to compare got with tt.want.
 			if got != tt.want {
-				t.Errorf("SiteInAudience() = %v, want %v", got, tt.want)
+				t.Errorf("SiteInAudience(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSiteInAudienceLegacyFormat(t *testing.T) {
+	claims := &VouchClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience: jwt.ClaimStrings{"vouch.github.io,other.test"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		s    string
+		want bool
+	}{
+		{"exact first", "vouch.github.io", true},
+		{"exact second", "other.test", true},
+		{"subdomain first", "sub.vouch.github.io", true},
+		{"subdomain second", "sub.other.test", true},
+		{"suffix attack first", "evilvouch.github.io", false},
+		{"suffix attack second", "evilother.test", false},
+		{"attacker parent", "vouch.github.io.attacker.com", false},
+		{"unrelated", "evil.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := claims.SiteInAudience(tt.s)
+			if got != tt.want {
+				t.Errorf("SiteInAudience(%q) = %v, want %v", tt.s, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #608.

The jwt/v4 to v5 migration changed the `aud` claim from a string to `[]string`. Old JWTs that were issued before the migration had all domains joined into a single comma-separated string (`"a.com,b.com"`). When jwt/v5 deserializes that, it produces a one-element `[]string` containing the whole thing: `["a.com,b.com"]`. `SiteInAudience` then tries to match against that single element, which obviously fails for any individual domain or subdomain.

This only affects users with two or more entries in `vouch.domains` (with a single domain there are no commas, so it round-trips fine).

The fix splits each audience element on commas before doing the domain match. For JWTs issued after the migration (where the audience is already a proper JSON array), `strings.Split` on a value with no commas returns a single-element slice, so the behavior is identical.

Also adds a subdomain test case to the existing `SiteInAudience` table test and a dedicated `TestSiteInAudienceLegacyFormat` covering exact match, subdomain match, and suffix attack prevention against a comma-separated audience string. Removes a stale TODO comment (the assertion was already implemented).

Repro: https://github.com/macourteau/vouch-proxy-608-repro