### PR TITLE
cfg: respect VOUCH_LOGLEVEL when no config file value is set

### DIFF
--- a/pkg/cfg/logging.go
+++ b/pkg/cfg/logging.go
@@ -103,7 +103,11 @@ func (logging) configure() {
 	}
 
 	// then we weren't configured via command line, check the config file
-	if !viper.IsSet(Branding.LCName + ".logLevel") {
+	// or the matching env var. envconfig writes to Cfg.LogLevel directly
+	// instead of going through viper, so viper.IsSet on its own wasn't
+	// enough to detect that the user had asked for a specific level via
+	// e.g. VOUCH_LOGLEVEL. See #540.
+	if !viper.IsSet(Branding.LCName+".logLevel") && os.Getenv(Branding.UCName+"_LOGLEVEL") == "" {
 		// then we weren't configured via the config file, set the default
 		Cfg.LogLevel = Logging.DefaultLogLevel.String()
 	}


### PR DESCRIPTION
Fixes #540.

\`Logging.configure()\` reset \`Cfg.LogLevel\` back to the default whenever \`viper.IsSet\` on the config-file key was false. \`envconfig\` (which is what reads \`VOUCH_LOGLEVEL\`) writes straight into \`Cfg.LogLevel\` and never goes through viper, so a user who set \`VOUCH_LOGLEVEL=debug\` without also putting \`logLevel\` in the config file always ended up back on info.

Also check the matching env var before clobbering the value, so an env-only configuration is honored. The config-file path still wins when both are present, matching the documented precedence.