### PR TITLE
fix panic in cookie.Cookie() on malformed multipart cookie names

### DIFF
--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -107,6 +107,9 @@ func Cookie(r *http.Request) (string, error) {
 			)
 			xOFy := strings.Replace(cookie.Name, cookieUnder, "", 1)
 			xyArray := strings.Split(xOFy, "of")
+			if len(xyArray) != 2 {
+				return "", fmt.Errorf("multipart cookie fail: invalid part count %s", xOFy)
+			}
 			if numParts == -1 { // then its uninitialized
 				if numParts, err = strconv.Atoi(xyArray[1]); err != nil {
 					return "", fmt.Errorf("multipart cookie fail: %s", err)
@@ -121,7 +124,7 @@ func Cookie(r *http.Request) (string, error) {
 			if i, err = strconv.Atoi(xyArray[0]); err != nil {
 				return "", fmt.Errorf("multipart cookie fail: %s", err)
 			}
-			if i > numParts {
+			if i < 1 || i > numParts {
 				return "", fmt.Errorf("multipart cookie fail: invalid part count %s", xOFy)
 			}
 			cookieParts[i-1] = cookie.Value

--- a/pkg/cookie/malformed_cookie_test.go
+++ b/pkg/cookie/malformed_cookie_test.go
@@ -1,0 +1,24 @@
+package cookie
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/vouch/vouch-proxy/pkg/cfg"
+)
+
+func TestMalformedMultipartCookieRejected(t *testing.T) {
+	cfg.Cfg.Cookie.Name = "vouch"
+	for _, ck := range []string{"vouch_1=x", "vouch_0of1=x", "vouch_-1of2=x", "vouch_2of1=x"} {
+		r := &http.Request{Header: map[string][]string{"Cookie": {ck}}}
+		if _, err := Cookie(r); err == nil {
+			t.Errorf("malformed cookie %q should return an error, got nil", ck)
+		}
+	}
+	// a valid multipart cookie still reassembles
+	r := &http.Request{Header: map[string][]string{"Cookie": {"vouch_1of2=foo", "vouch_2of2=bar"}}}
+	v, err := Cookie(r)
+	if err != nil || v != "foobar" {
+		t.Errorf("valid multipart cookie broke: got %q err=%v", v, err)
+	}
+}


### PR DESCRIPTION
Fixes #615.

Some malformed multipart cookie names panic `cookie.Cookie()` with an index out of range, reachable unauthenticated via `/validate`: a name without an `of` separator, or a part index outside `1..numParts`. CVE-2026-55149's fix covered the part count but not these.

Reject the name when the split isn't two parts, and require `1 <= i <= numParts`. Adds a regression test covering the malformed names and a valid multipart cookie.
